### PR TITLE
Fix bugs in Vagrantfile and init scripts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,9 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn", create: true, type: "rsync"
 
-  config.vbguest.auto_update = false
+  if Vagrant.has_plugin?("vagrant-vbguest")
+    config.vbguest.auto_update = false
+  end
   config.vm.provider :virtualbox do |vb|
       vb.check_guest_additions = false
       vb.functional_vboxsf = false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,40 +21,6 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--cpus", "1"]
   end
 
-  config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, inline: <<HERE
-echo 'Setting up correct env. variables'
-echo "export GOPATH=$GOPATH" >> /home/vagrant/.bash_profile
-echo "export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin" >> /home/vagrant/.bash_profile
-
-echo 'Writing build.sh'
-source ~/.bash_profile
-if [[ ! -f /home/vagrant/build.sh ]]; then
-cat >>/home/vagrant/build.sh <<-EOF
-#!/bin/bash
-set -xe
-
-cd $GOPATH/src/github.com/kinvolk/kube-spawn
-
-go get -u github.com/containernetworking/plugins/plugins/main/bridge
-go get -u github.com/containernetworking/plugins/plugins/ipam/host-local
-
-make vendor all
-
-sudo machinectl show-image coreos || sudo machinectl pull-raw --verify=no https://alpha.release.core-os.net/amd64-usr/current/coreos_developer_container.bin.bz2 coreos
-
-sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=1.6.6 up --nodes 2 --image coreos
-sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=1.6.6 init
-EOF
-fi
-HERE
-
-  config.vm.provision "shell", inline: <<HERE
-echo 'Modifying environment'
-chown -R vagrant:vagrant /home/vagrant
-chmod +x /home/vagrant/build.sh
-setenforce 0
-systemctl stop firewalld
-sudo groupadd docker && sudo gpasswd -a ${USER} docker && sudo systemctl restart docker && newgrp docker
-usermod -aG docker vagrant
-HERE
+  config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
+  config.vm.provision "shell", path: "scripts/vagrant-mod-env.sh"
 end

--- a/glide.lock
+++ b/glide.lock
@@ -1,27 +1,37 @@
-hash: 4fd9333c7f68ff1e551b0eb267aa915335782206a8501906e48ffc62e0400c1d
-updated: 2017-01-27T15:33:09.639904031+01:00
+hash: 7058458753d65f0b9cb4cd5094099f99a7e23bde9b37dd4ca72a67a97ef7a337
+updated: 2017-07-11T11:14:07.468254662+02:00
 imports:
 - name: github.com/containernetworking/cni
-  version: 5c3c17164270150467498a32c71436c7cd5501be
+  version: 137b4975ecab6e1f0c24c1e3c228a50a3cfba75e
+  subpackages:
+  - libcni
+  - pkg/invoke
+  - pkg/skel
+  - pkg/types
+  - pkg/types/020
+  - pkg/types/current
+  - pkg/version
+- name: github.com/containernetworking/plugins
+  version: 5bbff37294de9dfb33771dac6f53411c88abe62a
   subpackages:
   - pkg/ns
-  - pkg/types
 - name: github.com/docker/distribution
-  version: 7a0972304e201e2a5336a69d00e112c27823f554
+  version: f86db6b22663a27ba4d278220b7e34be528b1e79
   subpackages:
   - digestset
   - reference
 - name: github.com/docker/docker
-  version: fe5f49685df0d52127158f7e9a2882b8c4168dab
+  version: 3d6ab220db348d82310487e3156d445f19dc0661
   subpackages:
+  - api
   - api/types
   - api/types/blkiodev
   - api/types/container
   - api/types/events
   - api/types/filters
+  - api/types/image
   - api/types/mount
   - api/types/network
-  - api/types/reference
   - api/types/registry
   - api/types/strslice
   - api/types/swarm
@@ -29,48 +39,46 @@ imports:
   - api/types/versions
   - api/types/volume
   - client
+  - pkg/ioutils
+  - pkg/longpath
+  - pkg/mount
+  - pkg/system
   - pkg/tlsconfig
 - name: github.com/docker/go-connections
-  version: eb315e36415380e7c2fdee175262560ff42359da
+  version: 3ede32e2033de7505e6500d6c868c2b9ed9f169d
   subpackages:
   - nat
   - sockets
   - tlsconfig
 - name: github.com/docker/go-units
-  version: e30f1e79f3cd72542f2026ceec18d3bd67ab859c
-- name: github.com/dsnet/compress
-  version: b9aab3c6a04eef14c56384b4ad065e7b73438862
-  subpackages:
-  - bzip2
-  - bzip2/internal/sais
-  - internal
-  - internal/prefix
+  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
+- name: github.com/docker/libtrust
+  version: aabc10ec26b754e797f9028f4589c5b7bd90dc20
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/Masterminds/semver
+  version: abff1900528dbdaf6f3f5aa92c398be1eaf2a9f7
 - name: github.com/mholt/archiver
   version: 24d540239654d76e79c8f4e3d5bd56d90712becb
 - name: github.com/Microsoft/go-winio
-  version: 307e919c663683a9000576fdc855acaf9534c165
-- name: github.com/nwaples/rardecode
-  version: f22b7ef81a0afac9ce1447d37e5ab8e99fbd2f73
+  version: f533f7a102197536779ea3a8cb881d639e21ec5a
 - name: github.com/opencontainers/go-digest
-  version: 21dfd564fd89c944783d00d069f33e3e7123c448
-- name: github.com/pkg/errors
-  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
-- name: github.com/Sirupsen/logrus
-  version: 61e43dc76f7ee59a82bdf3d71033dc12bea4c77d
-- name: github.com/spf13/cobra
-  version: c29ece4386f74084680e5e6d02d7b943ae630f63
-- name: github.com/spf13/pflag
-  version: a9a634f3de0a7529baded7ad6b0c7467d5c6eca7
-- name: github.com/ulikunitz/xz
-  version: 76f94b7c69c6f84be96bcfc2443042b198689565
+  version: 279bed98673dd5bef374d3b6e4b09e2af76183bf
+- name: github.com/opencontainers/image-spec
+  version: 1b24aca6c83b826936087d56271f34fcef46c7b2
   subpackages:
-  - internal/hash
-  - internal/xlog
-  - lzma
+  - specs-go
+  - specs-go/v1
+- name: github.com/pkg/errors
+  version: c605e284fe17294bda444b34710735b29d1a9d90
+- name: github.com/Sirupsen/logrus
+  version: 3d4380f53a34dcdc95f0c1db702615992b38d9a4
+- name: github.com/spf13/cobra
+  version: 4d647c8944eb42504a714e57e97f244ed6344722
+- name: github.com/spf13/pflag
+  version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 - name: github.com/vishvananda/netlink
-  version: a4f22d8ad2327663017dbb309b5e3f8b6f348020
+  version: 4e28683688429fdf8413cc610d59fb1841986300
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
@@ -78,18 +86,15 @@ imports:
 - name: golang.org/x/crypto
   version: 41d678d1df78cd0410143162dff954e6dc09300f
   subpackages:
-  - curve25519
-  - ed25519
-  - ed25519/internal/edwards25519
   - ssh
 - name: golang.org/x/net
-  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
+  version: 8663ed5da4fd087c3cfb99a996e628b72e2f0948
   subpackages:
   - context
   - context/ctxhttp
   - proxy
 - name: golang.org/x/sys
-  version: e11762ca30adc5b39fdbfd8c4250dabeb8e456d3
+  version: 076b546753157f758b316e59bcb51e6807c04057
   subpackages:
   - unix
   - windows

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,3 +4,4 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - ssh
+- package: github.com/Masterminds/semver

--- a/scripts/vagrant-mod-env.sh
+++ b/scripts/vagrant-mod-env.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+USER=vagrant
+HOME=/home/${USER}
+
+echo 'Modifying environment'
+chown -R ${USER}:${USER} ${HOME}
+chmod +x ${HOME}/build.sh
+setenforce 0
+systemctl stop firewalld
+sudo groupadd docker && sudo gpasswd -a ${USER} docker && sudo systemctl restart docker && newgrp docker
+usermod -aG docker ${USER}

--- a/scripts/vagrant-mod-env.sh
+++ b/scripts/vagrant-mod-env.sh
@@ -12,3 +12,4 @@ setenforce 0
 systemctl stop firewalld
 sudo groupadd docker && sudo gpasswd -a ${USER} docker && sudo systemctl restart docker && newgrp docker
 usermod -aG docker ${USER}
+sudo modprobe overlay

--- a/scripts/vagrant-mod-env.sh
+++ b/scripts/vagrant-mod-env.sh
@@ -13,3 +13,7 @@ systemctl stop firewalld
 sudo groupadd docker && sudo gpasswd -a ${USER} docker && sudo systemctl restart docker && newgrp docker
 usermod -aG docker ${USER}
 sudo modprobe overlay
+
+NF_HASHSIZE=/sys/module/nf_conntrack/parameters/hashsize
+
+[ -f ${NF_HASHSIZE} ] && echo "131072" | sudo tee ${NF_HASHSIZE}

--- a/scripts/vagrant-setup-env.sh
+++ b/scripts/vagrant-setup-env.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -eo pipefail
+
+echo 'Setting up correct env. variables'
+echo "export GOPATH=$GOPATH" >> "$HOME/.bash_profile"
+echo "export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin" >> "$HOME/.bash_profile"
+
+# shellcheck disable=SC1090
+source ~/.bash_profile
+
+# -u must be set after "source ~/.bash_profile" to avoid errors like
+# "PS1: unbound variable"
+set -u
+
+echo 'Writing build.sh'
+
+if [[ ! -f $HOME/build.sh ]]; then
+	cat >>"$HOME/build.sh" <<-EOF
+#!/bin/bash
+set -xe
+
+cd $GOPATH/src/github.com/kinvolk/kube-spawn
+
+go get -u github.com/containernetworking/plugins/plugins/main/bridge
+go get -u github.com/containernetworking/plugins/plugins/ipam/host-local
+
+make vendor all
+
+sudo machinectl show-image coreos || sudo machinectl pull-raw --verify=no https://alpha.release.core-os.net/amd64-usr/current/coreos_developer_container.bin.bz2 coreos
+
+sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=1.6.6 up --nodes 2 --image coreos
+sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=1.6.6 init
+EOF
+fi

--- a/scripts/vagrant-setup-env.sh
+++ b/scripts/vagrant-setup-env.sh
@@ -30,7 +30,7 @@ make vendor all
 
 sudo machinectl show-image coreos || sudo machinectl pull-raw --verify=no https://alpha.release.core-os.net/amd64-usr/current/coreos_developer_container.bin.bz2 coreos
 
-sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=1.6.6 up --nodes 2 --image coreos
-sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=1.6.6 init
+sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=1.7.0 up --nodes 2 --image coreos
+sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=1.7.0 init
 EOF
 fi

--- a/scripts/vagrant-setup-env.sh
+++ b/scripts/vagrant-setup-env.sh
@@ -23,6 +23,7 @@ set -xe
 cd $GOPATH/src/github.com/kinvolk/kube-spawn
 
 go get -u github.com/containernetworking/plugins/plugins/main/bridge
+go get -u github.com/containernetworking/plugins/plugins/main/loopback
 go get -u github.com/containernetworking/plugins/plugins/ipam/host-local
 
 make vendor all


### PR DESCRIPTION
This PR contains multiple fixes to be able to run `kube-spawn` inside a Vagrant VM. The most critical one is the commit `"Vagrantfile: upgrade k8s to 1.7.0 for bugfixes"`.
 
* Vagrantfile: split out inline scripts into separate ones
* scripts: add kernel module for overlayfs
* scripts: add cni loopback plugin
* Vagrantfile: set vbguest config only if vbguest plugin is installed
* scripts: upgrade k8s to 1.7.0 for bugfixes
* kube-spawn: set the default k8s version to 1.7.0

This PR is basically a rebase of `"dongsu/devel-fix"` branch on top of the master branch. I'll update documents later when #52 got merged.

Fixes https://github.com/kinvolk/kube-spawn/issues/49