### PR TITLE
Vagrantfile, scripts: assign 2 CPUs and fix setup scripts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,8 +19,8 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |vb|
       vb.check_guest_additions = false
       vb.functional_vboxsf = false
-      vb.customize ["modifyvm", :id, "--memory", "4094"]
-      vb.customize ["modifyvm", :id, "--cpus", "1"]
+      vb.customize ["modifyvm", :id, "--memory", "4096"]
+      vb.customize ["modifyvm", :id, "--cpus", "2"]
   end
 
   config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"

--- a/scripts/vagrant-mod-env.sh
+++ b/scripts/vagrant-mod-env.sh
@@ -6,9 +6,12 @@ USER=vagrant
 HOME=/home/${USER}
 
 echo 'Modifying environment'
-chown -R ${USER}:${USER} ${HOME}
+chown -R ${USER}:${USER} ${HOME}/go/src/github.com/kinvolk/kube-spawn/k8s
 chmod +x ${HOME}/build.sh
-setenforce 0
+
+# setenforce always returns 1 when selinux is disabled.
+# we should ignore the error and continue.
+setenforce 0 || true
 systemctl stop firewalld
 sudo groupadd docker && sudo gpasswd -a ${USER} docker && sudo systemctl restart docker && newgrp docker
 usermod -aG docker ${USER}


### PR DESCRIPTION
In Vagrantfile, assign 2 CPUs for each VM to be able to build large source trees.
Also fix minor bugs in `vagrant-mod-env.sh`: Ignore return value of `setenforce`, as it always returns 1 if selinux is disabled. Also make sure that chmod runs only for a necessary directory k8s, instead of the whole home directory.