### PR TITLE
kube-spawn-runc: don't set Std{err,out,in} if we don't log

### DIFF
--- a/cmd/kube-spawn-runc/kube-spawn-runc.go
+++ b/cmd/kube-spawn-runc/kube-spawn-runc.go
@@ -59,9 +59,6 @@ func main() {
 		}
 	}
 	cmd := exec.Command(runcPath, newArgs...)
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	cmd.Stdin = os.Stdin
 	if err := cmd.Run(); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This avoids

```
fork/exec /run/torcx/bin/docker-runc: bad file descriptor
```

We haven't fully investigated why this happens but we don't really need
input/output for runc.