### PR TITLE
kube-spawn: enlarge storage pool for each cloned image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ ENV["LC_ALL"] = "en_US.UTF-8"
 
 Vagrant.configure("2") do |config|
   config.vm.box = "jhcook/fedora26"
-  config.vm.provision "shell", inline: "dnf install -y btrfs-progs docker git go kubernetes strace tmux"
+  config.vm.provision "shell", inline: "dnf install -y btrfs-progs docker git go kubernetes qemu-img strace tmux"
   # config.vm.box = "ubuntu/zesty64"
   # config.vm.provision "shell", inline: "DEBIAN_FRONTEND=noninteractive apt-get install -y golang git docker.io systemd-container tmux"
 

--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -25,9 +25,14 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"syscall"
 )
 
-const containerNameTemplate string = "kube-spawn-%d"
+const (
+	containerNameTemplate string = "kube-spawn-%d"
+	machinesDir           string = "/var/lib/machines"
+	machinesImage         string = "/var/lib/machines.raw"
+)
 
 type Node struct {
 	Name string
@@ -59,7 +64,7 @@ func NewNode(baseImage, machine string) error {
 
 func NodeExists(machine string) bool {
 	// TODO: we could also parse machinectl list-images to find that
-	if _, err := os.Stat(path.Join("/var/lib/machines/", machine+".raw")); err != nil {
+	if _, err := os.Stat(path.Join(machinesDir, machine+".raw")); err != nil {
 		if os.IsNotExist(err) {
 			return false
 		}
@@ -98,4 +103,197 @@ func GetRunningNodes() ([]Node, error) {
 	}
 
 	return nodes, nil
+}
+
+func EnlargeStoragePool(baseImage string, nodes int) error {
+	var poolSize int64 // in bytes
+
+	// Give 50% more space for each cloned image.
+	// NOTE: this is just a workaround, as how much space we should add more
+	// to the image might depend on estimations during run-time operations.
+	// In the long run, systemd itself should be able to reserve more space
+	// for the storage pool, every time when it pulls an image to store in
+	// the pool.
+	var extraSizeRatio float64 = 0.5
+
+	baseImageAbspath := path.Join(machinesDir, baseImage+".raw")
+
+	fipool, err := os.Stat(machinesImage)
+	if err != nil {
+		return err
+	}
+
+	poolSize = fipool.Size()
+
+	poolSize += int64(float64(fipool.Size()) * extraSizeRatio)
+
+	fiBase, err := os.Stat(baseImageAbspath)
+	if err != nil {
+		return err
+	}
+
+	poolSize += int64(float64(fiBase.Size())*extraSizeRatio) * int64(nodes)
+
+	// It is equivalent to the following shell commands:
+	//  # umount /var/lib/machines
+	//  # qemu-img resize -f raw /var/lib/machines.raw <poolsize>
+	//  # mount -t btrfs -o loop /var/lib/machines.raw /var/lib/machines
+	//  # btrfs filesystem resize max /var/lib/machines
+	//  # btrfs quota disable /var/lib/machines
+	if err := syscall.Unmount(machinesDir, 0); err != nil {
+		// if it's already unmounted, umount(2) returns EINVAL, then continue
+		if !os.IsNotExist(err) && err != syscall.EINVAL {
+			return err
+		}
+	}
+
+	if err := runImageResize(poolSize); err != nil {
+		// ignore image resize error, continue
+		log.Printf("image resize failed: %v\n", err)
+	}
+
+	if err := runMount(); err != nil {
+		return err
+	}
+
+	if err := runBtrfsResize(); err != nil {
+		// ignore image resize error, continue
+		log.Printf("btrfs resize failed: %v\n", err)
+	}
+
+	if err := runBtrfsDisableQuota(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func runImageResize(poolSize int64) error {
+	var cmdPath string
+	var err error
+
+	if cmdPath, err = exec.LookPath("qemu-img"); err != nil {
+		// fall back to an ordinary abspath to qemu-img
+		cmdPath = "/usr/bin/qemu-img"
+	}
+
+	args := []string{
+		cmdPath,
+		"resize",
+		"-f",
+		"raw",
+		machinesImage,
+		strconv.FormatInt(poolSize, 10),
+	}
+
+	cmd := exec.Cmd{
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running qemu-img: %s", err)
+	}
+
+	return nil
+}
+
+func runMount() error {
+	var cmdPath string
+	var err error
+
+	if cmdPath, err = exec.LookPath("mount"); err != nil {
+		// fall back to an ordinary abspath to qemu-img
+		cmdPath = "/usr/bin/mount"
+	}
+
+	args := []string{
+		cmdPath,
+		"-t",
+		"btrfs",
+		"-o",
+		"loop",
+		machinesImage,
+		machinesDir,
+	}
+
+	cmd := exec.Cmd{
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running mount: %s", err)
+	}
+
+	return nil
+}
+
+func runBtrfsResize() error {
+	var cmdPath string
+	var err error
+
+	if cmdPath, err = exec.LookPath("btrfs"); err != nil {
+		// fall back to an ordinary abspath to qemu-img
+		cmdPath = "/usr/sbin/btrfs"
+	}
+
+	args := []string{
+		cmdPath,
+		"filesystem",
+		"resize",
+		"max",
+		machinesDir,
+	}
+
+	cmd := exec.Cmd{
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running btrfs resize: %s", err)
+	}
+
+	return nil
+}
+
+func runBtrfsDisableQuota() error {
+	var cmdPath string
+	var err error
+
+	if cmdPath, err = exec.LookPath("btrfs"); err != nil {
+		// fall back to an ordinary abspath to qemu-img
+		cmdPath = "/usr/sbin/btrfs"
+	}
+
+	args := []string{
+		cmdPath,
+		"quota",
+		"disable",
+		machinesDir,
+	}
+
+	cmd := exec.Cmd{
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running btrfs quota: %s", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Enlarge the storage pool that is actually a btrfs volume backed by `/var/lib/machines.raw`. Every btrfs volume would need more space for its metadata as much as the volume grows through CoW operations. `/var/lib/machines` should have more space than its original image size. Otherwise `/var/lib/machines` could become full when files start to be written to nspawn containers.

In short, it's equivalent to the following command sequence:
<pre>
# umount /var/lib/machines
# qemu-img resize -f raw /var/lib/machines.raw POOLSIZE
# mount -t btrfs -o loop /var/lib/machines.raw /var/lib/machines
# btrfs filesystem resize max /var/lib/machines
# btrfs quota disable /var/lib/machines
</pre>

Unfortunately it's a temporary workaround. How much space we should add more to the image might depend on estimation during run-time operations. In the long run, systemd itself should be able to reserve more space for the storage pool, every time when it pulls an image to store in the pool.

Fixes https://github.com/kinvolk/kube-spawn/issues/66