### PR TITLE
Vagrantfile, script: let vagrant user own kube-spawn tree

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,11 @@ Vagrant.configure("2") do |config|
   # config.vm.provision "shell", inline: "DEBIAN_FRONTEND=noninteractive apt-get install -y golang git docker.io systemd-container tmux"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn", create: true, type: "rsync"
+  config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
+    create: true,
+    owner: "vagrant",
+    group: "vagrant",
+    type: "rsync"
 
   if Vagrant.has_plugin?("vagrant-vbguest")
     config.vbguest.auto_update = false
@@ -22,6 +26,10 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--memory", "4096"]
       vb.customize ["modifyvm", :id, "--cpus", "2"]
   end
+
+  # NOTE: chown is explicitly needed, even when synced_folder is configured
+  # with correct owner/group. Maybe a vagrant issue?
+  config.vm.provision "shell", inline: "mkdir -p /home/vagrant/go ; chown -R vagrant:vagrant /home/vagrant/go"
 
   config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
   config.vm.provision "shell", path: "scripts/vagrant-mod-env.sh"

--- a/scripts/vagrant-mod-env.sh
+++ b/scripts/vagrant-mod-env.sh
@@ -11,13 +11,12 @@ USER=vagrant
 HOME=/home/${USER}
 
 echo 'Modifying environment'
-chown -R ${USER}:${USER} ${HOME}/go/src/github.com/kinvolk/kube-spawn/k8s
 chmod +x ${HOME}/build.sh
 
 # setenforce always returns 1 when selinux is disabled.
 # we should ignore the error and continue.
 setenforce 0 || true
-systemctl stop firewalld
+systemctl is-active firewalld 1>/dev/null && systemctl stop firewalld
 groupadd docker && gpasswd -a ${USER} docker && systemctl restart docker && newgrp docker
 usermod -aG docker ${USER}
 


### PR DESCRIPTION
The git tree `go/src/github.com/kinvolk/kube-spawn` should be owned by vagrant:vagrant. Allow Vagrantfile to set it via `vm_synced_folder`. Then we don't need to run it from `vagrant-mod-env.sh`.

Also stop firewalld only if it's already started. Otherwise it could fail when firewalld is stopped.