### PR TITLE
kube-spawn: ensure that system requirements are satisfied

### DIFF
--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -148,7 +148,6 @@ func RunNode(k8srelease, name string) error {
 		check := exec.Command("systemctl", "--machine", name, "status", "basic.target", "--state=running")
 		check.Run()
 		if ready = check.ProcessState.Success(); !ready {
-			log.Printf("%+v", check.ProcessState)
 			time.Sleep(2 * time.Second)
 			retries++
 		}


### PR DESCRIPTION
Ensure that the system requirements are satisfied for starting `kube-spawn`. It's just like running the commands below:

<pre>
# modprobe overlay
# modprobe nf_conntrack
# echo "131072" > /sys/module/nf_conntrack/parameters/hashsize
</pre>

It was originally done by `scripts/vagrant-mod-env.sh`. However it's actually hard for end-users to take care of the requirements prior to running `kube-spawn`. So allow `kube-spawn` to do the initialization by itself a bit actively.

Also remove unnecessary warnings `"exit status 1"` while waiting on completion.

Fixes https://github.com/kinvolk/kube-spawn/issues/69
