### PR TITLE
Vagrantfile: support multiple machines

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
   end
 
   # Fedora 26
-  config.vm.define "fedora" do |fedora|
+  config.vm.define "fedora", primary: true do |fedora|
     config.vm.provision "shell", inline: "dnf install -y btrfs-progs docker git go kubernetes qemu-img strace tmux"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
   end
 
   # Ubuntu 17.04 (Zesty)
-  config.vm.define "ubuntu" do |ubuntu|
+  config.vm.define "ubuntu", autostart: false do |ubuntu|
     config.vm.box = "ubuntu/zesty64"
     config.vm.provision "shell", inline: "curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -; echo \"deb http://apt.kubernetes.io/ kubernetes-xenial main\" > /etc/apt/sources.list.d/kubernetes.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io golang git qemu-utils selinux-utils systemd-container kubectl tmux"
 
@@ -55,7 +55,7 @@ Vagrant.configure("2") do |config|
   end
 
   # Debian testing
-  config.vm.define "debian" do |debian|
+  config.vm.define "debian", autostart: false do |debian|
     config.vm.box = "debian/testing64"
     config.vm.provision "shell", inline: "echo deb http://apt.dockerproject.org/repo debian-stretch main > /etc/apt/sources.list.d/docker.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated docker-engine; DEBIAN_FRONTEND=noninteractive apt-get install -y golang git kubernetes-client qemu-utils selinux-utils systemd-container tmux"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,36 +1,73 @@
 # -*- mode: ruby -*-
-# vi: set ft=ruby :
+# vi: set ft=ruby sw=2 ts=2 :
 
 ENV["TERM"] = "xterm-256color"
 ENV["LC_ALL"] = "en_US.UTF-8"
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "jhcook/fedora26"
-  config.vm.provision "shell", inline: "dnf install -y btrfs-progs docker git go kubernetes qemu-img strace tmux"
-  # config.vm.box = "ubuntu/zesty64"
-  # config.vm.provision "shell", inline: "DEBIAN_FRONTEND=noninteractive apt-get install -y golang git docker.io systemd-container tmux"
+  config.vm.box = "jhcook/fedora26" # defaults to fedora
 
-  config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
-    create: true,
-    owner: "vagrant",
-    group: "vagrant",
-    type: "rsync"
-
+  # common parts
   if Vagrant.has_plugin?("vagrant-vbguest")
     config.vbguest.auto_update = false
   end
   config.vm.provider :virtualbox do |vb|
-      vb.check_guest_additions = false
-      vb.functional_vboxsf = false
-      vb.customize ["modifyvm", :id, "--memory", "4096"]
-      vb.customize ["modifyvm", :id, "--cpus", "2"]
+    vb.check_guest_additions = false
+    vb.functional_vboxsf = false
+    vb.customize ["modifyvm", :id, "--memory", "4096"]
+    vb.customize ["modifyvm", :id, "--cpus", "2"]
   end
 
-  # NOTE: chown is explicitly needed, even when synced_folder is configured
-  # with correct owner/group. Maybe a vagrant issue?
-  config.vm.provision "shell", inline: "mkdir -p /home/vagrant/go ; chown -R vagrant:vagrant /home/vagrant/go"
+  # Fedora 26
+  config.vm.define "fedora" do |fedora|
+    config.vm.provision "shell", inline: "dnf install -y btrfs-progs docker git go kubernetes qemu-img strace tmux"
 
-  config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
-  config.vm.provision "shell", path: "scripts/vagrant-mod-env.sh"
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+    config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
+      create: true,
+      owner: "vagrant",
+      group: "vagrant",
+      type: "rsync"
+
+    # NOTE: chown is explicitly needed, even when synced_folder is configured
+    # with correct owner/group. Maybe a vagrant issue?
+    config.vm.provision "shell", inline: "mkdir -p /home/vagrant/go ; chown -R vagrant:vagrant /home/vagrant/go"
+
+    config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
+    config.vm.provision "shell", env: {"VUSER" => "vagrant"}, path: "scripts/vagrant-mod-env.sh"
+  end
+
+  # Ubuntu 17.04 (Zesty)
+  config.vm.define "ubuntu" do |ubuntu|
+    config.vm.box = "ubuntu/zesty64"
+    config.vm.provision "shell", inline: "curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -; echo \"deb http://apt.kubernetes.io/ kubernetes-xenial main\" > /etc/apt/sources.list.d/kubernetes.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io golang git qemu-utils selinux-utils systemd-container kubectl tmux"
+
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+    config.vm.synced_folder ".", "/home/ubuntu/go/src/github.com/kinvolk/kube-spawn",
+      create: true,
+      owner: "ubuntu",
+      group: "ubuntu",
+      type: "rsync"
+
+    config.vm.provision "shell", inline: "mkdir -p /home/ubuntu/go ; chown -R ubuntu:ubuntu /home/ubuntu/go"
+    config.vm.provision "shell", env: {"GOPATH" => "/home/ubuntu/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
+    config.vm.provision "shell", env: {"VUSER" => "ubuntu"}, path: "scripts/vagrant-mod-env.sh"
+  end
+
+  # Debian testing
+  config.vm.define "debian" do |debian|
+    config.vm.box = "debian/testing64"
+    config.vm.provision "shell", inline: "echo deb http://apt.dockerproject.org/repo debian-stretch main > /etc/apt/sources.list.d/docker.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated docker-engine; DEBIAN_FRONTEND=noninteractive apt-get install -y golang git kubernetes-client qemu-utils selinux-utils systemd-container tmux"
+
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+    config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
+      create: true,
+      owner: "vagrant",
+      group: "vagrant",
+      type: "rsync"
+
+    config.vm.provision "shell", inline: "mkdir -p /home/vagrant/go ; chown -R vagrant:vagrant /home/vagrant/go"
+    config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
+    config.vm.provision "shell", env: {"VUSER" => "vagrant"}, path: "scripts/vagrant-mod-env.sh"
+  end
 end

--- a/scripts/vagrant-mod-env.sh
+++ b/scripts/vagrant-mod-env.sh
@@ -1,24 +1,41 @@
 #!/bin/bash
 
-set -euo pipefail
+# Run it with env variable $VUSER set to a customized user, other than the
+# default user "vagrant". For example on Ubuntu VM on Vagrant:
+#
+#  $ sudo VUSER=ubuntu ./vagrant-mod-env.sh
+
+set -eo pipefail
 
 if [ ${EUID} -ne 0 ]; then
 	echo "This script must be run as root"
 	exit 1
 fi
 
-USER=vagrant
-HOME=/home/${USER}
+if [ "${VUSER}" == "" ]; then
+	VUSER=vagrant
+fi
+
+set -u
+
+HOME=/home/${VUSER}
 
 echo 'Modifying environment'
 chmod +x ${HOME}/build.sh
 
 # setenforce always returns 1 when selinux is disabled.
 # we should ignore the error and continue.
-setenforce 0 || true
+/usr/sbin/setenforce 0 || true
+
+# Stop firewalld to allow traffic by default.
+# Note that especially on Debian systems, it's not sufficient to stop
+# firewalld, because the FORWARD chain's policy is still DROP.
 systemctl is-active firewalld 1>/dev/null && systemctl stop firewalld
-groupadd docker && gpasswd -a ${USER} docker && systemctl restart docker && newgrp docker
-usermod -aG docker ${USER}
+iptables -P FORWARD ACCEPT
+sysctl -w net.ipv4.ip_forward=1
+
+groupadd docker && gpasswd -a ${VUSER} docker && systemctl restart docker && newgrp docker
+usermod -aG docker ${VUSER}
 
 modprobe overlay
 modprobe nf_conntrack


### PR DESCRIPTION
Support both Fedora 26, Ubuntu 17.04 (Zesty), and Debian testing. It defaults to Fedora like before.
Also update `vagrant-mod-env.sh` to support both usernames, `vagrant` and `ubuntu`.
