### PR TITLE
scripts: mask systemd-networkd-wait-online.service

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -7,3 +7,6 @@ echo "root:k8s" | chpasswd
 systemctl enable docker.service
 systemctl enable kubelet.service
 systemctl enable sshd.service
+
+# necessary to prevent docker from being blocked.
+systemctl mask systemd-networkd-wait-online.service

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,6 +3,7 @@
 set -ex
 
 echo "root:k8s" | chpasswd
+echo "core:core" | chpasswd
 
 systemctl enable docker.service
 systemctl enable kubelet.service


### PR DESCRIPTION
Every time when `docker.service` runs, it waits for 120 seconds doing nothing, until `systemd-networkd-wait-online.service` times out. As a result, kubeadm is being blocked until docker server became available: a huge delay for every nspawn container, although network is already online and reachable.

Let's just mask `systemd-networkd-wait-online.service`, to allow `docker.service` to run without being blocked.

Fixes https://github.com/kinvolk/kube-spawn/issues/75