### PR TITLE
kube-spawn: add start/stop commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ make vendor all
 $ sudo machinectl pull-raw --verify=no https://alpha.release.core-os.net/amd64-usr/current/coreos_developer_container.bin.bz2 coreos
 
 # Spawn and provision nodes for the cluster
-$ sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn up --image=coreos --nodes=3
+$ sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn setup --image=coreos --nodes=3
 
 # Setup Kubernetes
 $ sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn init
@@ -82,7 +82,7 @@ Assuming you have built `kube-spawn` and pulled the CoreOS image, do:
 
 ```
 # Spawn and provision nodes for the cluster
-$ sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=dev up --image=coreos --nodes=3
+$ sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=dev setup --image=coreos --nodes=3
 
 # Setup Kubernetes
 $ sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=dev init

--- a/cmd/kube-spawn/init.go
+++ b/cmd/kube-spawn/init.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
+	"github.com/kinvolk/kube-spawn/pkg/distribution"
+	"github.com/kinvolk/kube-spawn/pkg/nspawntool"
+)
+
+const pushImageRetries int = 10
+
+var (
+	cmdInit = &cobra.Command{
+		Use:   "init",
+		Short: "Initialize cluster running kubeadm",
+		Run:   runInit,
+	}
+)
+
+func init() {
+	cmdKubeSpawn.AddCommand(cmdInit)
+}
+
+func isDev(k8srel string) bool {
+	return k8srel == "" || k8srel == "dev"
+}
+
+func runInit(cmd *cobra.Command, args []string) {
+	doInit()
+}
+
+func doInit() {
+	doCheckK8sStableRelease(k8srelease)
+
+	if isDev(k8srelease) {
+		// we don't need to run a docker registry
+		if err := distribution.StartRegistry(); err != nil {
+			log.Fatalf("Error starting registry: %s", err)
+		}
+		var err error
+		for i := 0; i < pushImageRetries; i++ {
+			err = distribution.PushImage()
+			if err == nil {
+				break
+			}
+			time.Sleep(1 * time.Second)
+		}
+		if err != nil {
+			log.Fatalf("Error pushing hyperkube image: %s", err)
+		}
+	}
+
+	nodes, err := bootstrap.GetRunningNodes()
+	if err != nil {
+		log.Fatalf("Error listing running nodes: %s", err)
+	}
+	if len(nodes) == 0 {
+		log.Fatal("No node running. Is systemd-nspawn running correctly?")
+	}
+
+	bootstrap.EnsureRequirements()
+
+	log.Println("Note: init on master can take a couple of minutes until every k8s pod came up.")
+
+	if err := nspawntool.InitializeMaster(k8srelease, nodes[0].Name); err != nil {
+		log.Fatalf("Error initializing master node %s: %s", nodes[0].Name, err)
+	}
+
+	for i, node := range nodes {
+		if i != 0 {
+			if err := nspawntool.JoinNode(k8srelease, node.Name, nodes[0].IP); err != nil {
+				log.Fatalf("Error joining worker node %s: %s", node.Name, err)
+			}
+		}
+	}
+}

--- a/cmd/kube-spawn/kube-spawn.go
+++ b/cmd/kube-spawn/kube-spawn.go
@@ -75,7 +75,7 @@ func isDev(k8srel string) bool {
 	return k8srel == "" || k8srel == "dev"
 }
 
-func runUp(cmd *cobra.Command, args []string) {
+func runSetup(cmd *cobra.Command, args []string) {
 	if err := bootstrap.EnsureBridge(); err != nil {
 		log.Fatalf("Error checking CNI bridge: %s", err)
 	}
@@ -140,11 +140,11 @@ func runUp(cmd *cobra.Command, args []string) {
 	log.Printf("All nodes are running. Use machinectl to login/stop/etc.")
 }
 
-func newUpCommand() *cobra.Command {
+func newSetupCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "up",
+		Use:   "setup",
 		Short: "Start nodes",
-		Run:   runUp,
+		Run:   runSetup,
 	}
 	cmd.Flags().IntVarP(&numNodes, "nodes", "n", 1, "number of nodes to spawn")
 	cmd.Flags().StringVarP(&baseImage, "image", "i", "", "base image for nodes")
@@ -223,7 +223,7 @@ func newKubeadmNspawnCommand() *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&printVersion, "version", "V", false, "output version information")
 	cmd.PersistentFlags().StringVarP(&k8srelease, "kubernetes-version", "k", k8sStableVersion, "Kubernetes version to spawn, \"\" or \"dev\" for self-building upstream K8s.")
-	cmd.AddCommand(newUpCommand())
+	cmd.AddCommand(newSetupCommand())
 	cmd.AddCommand(newInitCommand())
 	return cmd
 }

--- a/cmd/kube-spawn/kube-spawn.go
+++ b/cmd/kube-spawn/kube-spawn.go
@@ -20,194 +20,14 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/spf13/cobra"
-
-	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
-	"github.com/kinvolk/kube-spawn/pkg/distribution"
-	"github.com/kinvolk/kube-spawn/pkg/nspawntool"
 )
 
-const (
-	pushImageRetries int    = 10
-	k8sStableVersion string = "1.7.0"
-)
+const k8sStableVersion string = "1.7.0"
 
 var (
-	version      string
-	gopath       string = os.Getenv("GOPATH")
-	numNodes     int
-	k8srelease   string
-	printVersion bool
-	baseImage    string
-)
-
-func checkK8sStableRelease(k8srel string) bool {
-	v, err := semver.NewVersion(k8srel)
-	if err != nil {
-		// fallback to default version
-		v, _ = semver.NewVersion(k8sStableVersion)
-	}
-
-	c, err := semver.NewConstraint(">=" + k8sStableVersion)
-	if err != nil {
-		log.Printf("Cannot get constraint for >= %s: %v", k8sStableVersion, err)
-		return false
-	}
-
-	return c.Check(v)
-}
-
-func doCheckK8sStableRelease(k8srel string) {
-	if !checkK8sStableRelease(k8srelease) {
-		log.Printf("WARNING: K8s with version <%s is not compatible with kube-spawn.",
-			k8sStableVersion)
-		log.Printf("It's highly recommended to upgrade K8s to 1.7 or newer.")
-		// Print a kind warning, and continue to run.
-		// It should still allow kubeadm to run with Kubernetes <1.7,
-		// to be able to allow end users to flexibly handle various cases.
-	}
-}
-
-func isDev(k8srel string) bool {
-	return k8srel == "" || k8srel == "dev"
-}
-
-func runSetup(cmd *cobra.Command, args []string) {
-	if err := bootstrap.EnsureBridge(); err != nil {
-		log.Fatalf("Error checking CNI bridge: %s", err)
-	}
-
-	if err := bootstrap.WriteNetConf(); err != nil {
-		log.Fatalf("Error writing CNI configuration: %s", err)
-	}
-
-	log.Printf("Checking base image")
-	if baseImage == "" {
-		log.Fatal("No base image specified.")
-	}
-	if !bootstrap.MachineImageExists(baseImage) {
-		log.Fatal("Base image not found.")
-	}
-
-	bootstrap.CreateSharedTmpdir()
-
-	doCheckK8sStableRelease(k8srelease)
-
-	if !isDev(k8srelease) {
-		if err := bootstrap.DownloadK8sBins(k8srelease, "./k8s"); err != nil {
-			log.Fatalf("Error downloading k8s files: %s", err)
-		}
-	}
-
-	var nodesToRun []string
-
-	for i := 0; i < numNodes; i++ {
-		name := bootstrap.GetNodeName(i)
-		if !bootstrap.MachineImageExists(name) {
-			if err := bootstrap.NewNode(baseImage, name); err != nil {
-				log.Fatalf("Error cloning base image: %s", err)
-			}
-		}
-		if bootstrap.IsNodeRunning(name) {
-			continue
-		}
-		nodesToRun = append(nodesToRun, name)
-	}
-	if len(nodesToRun) == 0 {
-		log.Printf("No nodes to create. stop")
-		os.Exit(1)
-	}
-
-	if err := bootstrap.EnlargeStoragePool(baseImage, len(nodesToRun)); err != nil {
-		log.Printf("Warning: cannot enlarge storage pool: %s", err)
-	}
-
-	for _, name := range nodesToRun {
-		if err := nspawntool.RunNode(k8srelease, name); err != nil {
-			log.Fatalf("Error running node: %s", err)
-		}
-
-		if err := nspawntool.RunBootstrapScript(name); err != nil {
-			log.Fatalf("Error running bootstrap script: %s", err)
-		}
-
-		log.Printf("Success! %s started.", name)
-	}
-
-	log.Printf("All nodes are running. Use machinectl to login/stop/etc.")
-}
-
-func newSetupCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "setup",
-		Short: "Start nodes",
-		Run:   runSetup,
-	}
-	cmd.Flags().IntVarP(&numNodes, "nodes", "n", 1, "number of nodes to spawn")
-	cmd.Flags().StringVarP(&baseImage, "image", "i", "", "base image for nodes")
-	return cmd
-}
-
-func runInit(cmd *cobra.Command, args []string) {
-	doCheckK8sStableRelease(k8srelease)
-
-	if isDev(k8srelease) {
-		// we don't need to run a docker registry
-		if err := distribution.StartRegistry(); err != nil {
-			log.Fatalf("Error starting registry: %s", err)
-		}
-		var err error
-		for i := 0; i < pushImageRetries; i++ {
-			err = distribution.PushImage()
-			if err == nil {
-				break
-			}
-			time.Sleep(1 * time.Second)
-		}
-		if err != nil {
-			log.Fatalf("Error pushing hyperkube image: %s", err)
-		}
-	}
-
-	nodes, err := bootstrap.GetRunningNodes()
-	if err != nil {
-		log.Fatalf("Error listing running nodes: %s", err)
-	}
-	if len(nodes) == 0 {
-		log.Fatal("No node running. Is systemd-nspawn running correctly?")
-	}
-
-	bootstrap.EnsureRequirements()
-
-	log.Println("Note: init on master can take a couple of minutes until every k8s pod came up.")
-
-	if err := nspawntool.InitializeMaster(k8srelease, nodes[0].Name); err != nil {
-		log.Fatalf("Error initializing master node %s: %s", nodes[0].Name, err)
-	}
-
-	for i, node := range nodes {
-		if i != 0 {
-			if err := nspawntool.JoinNode(k8srelease, node.Name, nodes[0].IP); err != nil {
-				log.Fatalf("Error joining worker node %s: %s", node.Name, err)
-			}
-		}
-	}
-}
-
-func newInitCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Execute kubeadm",
-		Run:   runInit,
-	}
-	return cmd
-}
-
-func newKubeadmNspawnCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmdKubeSpawn = &cobra.Command{
 		Use:   "kube-spawn",
 		Short: "kube-spawn is a tool for creating a multi-node dev Kubernetes cluster",
 		Long:  "kube-spawn is a tool for creating a multi-node dev Kubernetes cluster, by using the local source code and systemd-nspawn containers",
@@ -221,15 +41,20 @@ func newKubeadmNspawnCommand() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().BoolVarP(&printVersion, "version", "V", false, "output version information")
-	cmd.PersistentFlags().StringVarP(&k8srelease, "kubernetes-version", "k", k8sStableVersion, "Kubernetes version to spawn, \"\" or \"dev\" for self-building upstream K8s.")
-	cmd.AddCommand(newSetupCommand())
-	cmd.AddCommand(newInitCommand())
-	return cmd
+
+	version      string
+	gopath       string = os.Getenv("GOPATH")
+	k8srelease   string
+	printVersion bool
+)
+
+func init() {
+	cmdKubeSpawn.Flags().BoolVarP(&printVersion, "version", "V", false, "output version information")
+	cmdKubeSpawn.PersistentFlags().StringVarP(&k8srelease, "kubernetes-version", "k", k8sStableVersion, "Kubernetes version to spawn, \"\" or \"dev\" for self-building upstream K8s.")
 }
 
 func main() {
-	if err := newKubeadmNspawnCommand().Execute(); err != nil {
+	if err := cmdKubeSpawn.Execute(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/kube-spawn/setup.go
+++ b/cmd/kube-spawn/setup.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+
+	"github.com/Masterminds/semver"
+	"github.com/spf13/cobra"
+
+	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
+	"github.com/kinvolk/kube-spawn/pkg/nspawntool"
+)
+
+var (
+	nodes     int
+	baseImage string
+
+	cmdSetup = &cobra.Command{
+		Use:   "setup",
+		Short: "Set up nodes bringing up nspawn containers",
+		Run:   runSetup,
+	}
+)
+
+func init() {
+	cmdKubeSpawn.AddCommand(cmdSetup)
+
+	cmdSetup.Flags().IntVarP(&nodes, "nodes", "n", 1, "number of nodes to spawn")
+	cmdSetup.Flags().StringVarP(&baseImage, "image", "i", "", "base image for nodes")
+}
+
+func checkK8sStableRelease(k8srel string) bool {
+	v, err := semver.NewVersion(k8srel)
+	if err != nil {
+		// fallback to default version
+		v, _ = semver.NewVersion(k8sStableVersion)
+	}
+
+	c, err := semver.NewConstraint(">=" + k8sStableVersion)
+	if err != nil {
+		log.Printf("Cannot get constraint for >= %s: %v", k8sStableVersion, err)
+		return false
+	}
+
+	return c.Check(v)
+}
+
+func doCheckK8sStableRelease(k8srel string) {
+	if !checkK8sStableRelease(k8srelease) {
+		log.Printf("WARNING: K8s with version <%s is not compatible with kube-spawn.",
+			k8sStableVersion)
+		log.Printf("It's highly recommended to upgrade K8s to 1.7 or newer.")
+		// Print a kind warning, and continue to run.
+		// It should still allow kubeadm to run with Kubernetes <1.7,
+		// to be able to allow end users to flexibly handle various cases.
+	}
+}
+
+func runSetup(cmd *cobra.Command, args []string) {
+	doSetup(nodes, baseImage)
+}
+
+func doSetup(nodes int, baseImage string) {
+	if err := bootstrap.EnsureBridge(); err != nil {
+		log.Fatalf("Error checking CNI bridge: %s", err)
+	}
+
+	if err := bootstrap.WriteNetConf(); err != nil {
+		log.Fatalf("Error writing CNI configuration: %s", err)
+	}
+
+	log.Printf("Checking base image")
+	if baseImage == "" {
+		log.Fatal("No base image specified.")
+	}
+	if !bootstrap.MachineImageExists(baseImage) {
+		log.Fatal("Base image not found.")
+	}
+
+	bootstrap.CreateSharedTmpdir()
+
+	doCheckK8sStableRelease(k8srelease)
+
+	if !isDev(k8srelease) {
+		if err := bootstrap.DownloadK8sBins(k8srelease, "./k8s"); err != nil {
+			log.Fatalf("Error downloading k8s files: %s", err)
+		}
+	}
+
+	var nodesToCreate []string
+
+	for i := 0; i < nodes; i++ {
+		name := bootstrap.GetNodeName(i)
+		if bootstrap.MachineImageExists(name) {
+			continue
+		}
+		if err := bootstrap.NewNode(baseImage, name); err != nil {
+			log.Fatalf("Error cloning base image: %s", err)
+		}
+		nodesToCreate = append(nodesToCreate, name)
+	}
+
+	if err := bootstrap.EnlargeStoragePool(baseImage, len(nodesToCreate)); err != nil {
+		log.Printf("Warning: cannot enlarge storage pool: %s", err)
+	}
+
+	for _, name := range nodesToCreate {
+		if err := nspawntool.RunNode(k8srelease, name); err != nil {
+			log.Fatalf("Error running node: %s", err)
+		}
+
+		if err := nspawntool.RunBootstrapScript(name); err != nil {
+			log.Fatalf("Error running bootstrap script: %s", err)
+		}
+
+		log.Printf("Success! %s started.", name)
+	}
+
+	log.Printf("All nodes are running. Use machinectl to login/stop/etc.")
+}

--- a/cmd/kube-spawn/start.go
+++ b/cmd/kube-spawn/start.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdStart = &cobra.Command{
+		Use:   "start",
+		Short: "Start nodes pulling raw image, running setup and init",
+		Run:   runStart,
+	}
+)
+
+func init() {
+	cmdKubeSpawn.AddCommand(cmdStart)
+}
+
+func runStart(cmd *cobra.Command, args []string) {
+	if len(args) != 0 {
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	if err := showImage(); err != nil {
+		if err := pullRawImage(); err != nil {
+			log.Fatalf("%v\n", err)
+		}
+	}
+
+	// sudo ./kube-spawn setup --nodes=2 --image=coreos
+	doSetup(2, "coreos")
+
+	// sudo ./kube-spawn init
+	doInit()
+
+	log.Printf("All nodes are started.")
+}
+
+func pullRawImage() error {
+	var cmdPath string
+	var err error
+
+	if cmdPath, err = exec.LookPath("machinectl"); err != nil {
+		// fall back to an ordinary abspath to machinectl
+		cmdPath = "/usr/bin/machinectl"
+	}
+
+	args := []string{
+		cmdPath,
+		"pull-raw",
+		"--verify=no",
+		"https://alpha.release.core-os.net/amd64-usr/current/coreos_developer_container.bin.bz2",
+		"coreos",
+	}
+
+	cmd := exec.Cmd{
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running machinectl pull-raw: %s", err)
+	}
+
+	return nil
+}
+
+func showImage() error {
+	var cmdPath string
+	var err error
+
+	if cmdPath, err = exec.LookPath("machinectl"); err != nil {
+		// fall back to an ordinary abspath to machinectl
+		cmdPath = "/usr/bin/machinectl"
+	}
+
+	args := []string{
+		cmdPath,
+		"show-image",
+		"coreos",
+	}
+
+	cmd := exec.Cmd{
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running machinectl show-image: %s", err)
+	}
+
+	return nil
+}

--- a/cmd/kube-spawn/stop.go
+++ b/cmd/kube-spawn/stop.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
+)
+
+var (
+	cmdStop = &cobra.Command{
+		Use:   "stop",
+		Short: "Stop nodes by turning off machines",
+		Run:   runStop,
+	}
+
+	isForce bool
+)
+
+func init() {
+	cmdKubeSpawn.AddCommand(cmdStop)
+	cmdStop.Flags().BoolVarP(&isForce, "force", "f", false, "force the machine to be terminated")
+}
+
+func runStop(cmd *cobra.Command, args []string) {
+	if len(args) != 0 {
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	var machs []string
+
+	nodes, err := bootstrap.GetRunningNodes()
+	if err != nil {
+		log.Printf("%v", err)
+	}
+	if len(nodes) > 0 {
+		for _, n := range nodes {
+			machs = append(machs, n.Name)
+		}
+
+		log.Printf("turning off machines %v...\n", machs)
+		if err := stopMachines(machs); err != nil {
+			log.Printf("%v\n", err)
+		}
+	}
+	log.Printf("All nodes are stopped.")
+}
+
+func stopMachines(machs []string) error {
+	var cmdPath string
+	var err error
+
+	if cmdPath, err = exec.LookPath("machinectl"); err != nil {
+		// fall back to an ordinary abspath to machinectl
+		cmdPath = "/usr/bin/machinectl"
+	}
+
+	argsOff := []string{
+		cmdPath,
+	}
+
+	if isForce {
+		argsOff = append(argsOff, "terminate")
+	} else {
+		argsOff = append(argsOff, "poweroff")
+	}
+
+	for _, m := range machs {
+		args := append(argsOff, m)
+
+		cmd := exec.Cmd{
+			Path:   cmdPath,
+			Args:   args,
+			Env:    os.Environ(),
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
+		}
+
+		if err := cmd.Run(); err != nil {
+			log.Printf("error running %v: %s", args, err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/kube-spawn/up.go
+++ b/cmd/kube-spawn/up.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdUp = &cobra.Command{
+		Use:   "up",
+		Short: "Set up nodes bringing up nspawn containers (deprecated)",
+		Run:   runUp,
+	}
+)
+
+func init() {
+	cmdKubeSpawn.AddCommand(cmdUp)
+}
+
+func runUp(cmd *cobra.Command, args []string) {
+	log.Printf("WARNING: up command is deprecated. Please run setup command instead.")
+	os.Exit(1)
+}

--- a/scripts/vagrant-setup-env.sh
+++ b/scripts/vagrant-setup-env.sh
@@ -30,7 +30,7 @@ make vendor all
 
 sudo machinectl show-image coreos || sudo machinectl pull-raw --verify=no https://alpha.release.core-os.net/amd64-usr/current/coreos_developer_container.bin.bz2 coreos
 
-sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=1.7.0 up --nodes 2 --image coreos
+sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=1.7.0 setup --nodes 2 --image coreos
 sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=1.7.0 init
 EOF
 fi


### PR DESCRIPTION
* rename command from `up` to `setup`
* split out commands into multiple files to maintain the source tree better. `init.go` for init command, `setup.go` for setup command etc.
* introduce `start` and `stop` commands. `start` wraps `machinectl pull ... coreos`, `setup` and `init`. `stop` does what `machinectl stop kube-spawn-{0,...,n}` would achieve

Fixes https://github.com/kinvolk/kube-spawn/issues/54