### PR TITLE
cnispawn, nspawntool: check GOPATH, CNI_PATH in a flexible way

### DIFF
--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -143,7 +143,7 @@ func RunNode(k8srelease, name string) error {
 
 	if err := c.Wait(); err != nil {
 		var cniError cnitypes.Error
-		if err := json.Unmarshal(cniDataJSON, &cniError); err == nil {
+		if err := json.Unmarshal(cniDataJSON, &cniError); err != nil {
 			return fmt.Errorf("error unmarshaling cni error: %s", err)
 		}
 		return fmt.Errorf("error running cnispawn: %s", cniError)

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -35,19 +35,8 @@ const bindro string = "--bind-ro="
 const bindrw string = "--bind="
 
 var (
-	gopath  string = os.Getenv("GOPATH")
-	cnipath string = os.Getenv("CNI_PATH")
-	// binariesDir  string = path.Join(gopath, "src", "k8s.io", "kubernetes", "_output", "bin")
-	// binariesDest string = path.Join("usr", "bin")
-
-	// cniDir  string = path.Join(gopath, "src", "github.com", "containernetworking", "cni", "bin")
-	// cniDest string = path.Join("opt", "cni", "bin")
-
-	// kubeletConfigPath string = path.Join(gopath, "src", "k8s.io", "release", "rpm", "10-kubeadm.conf")
-	// kubeletConfigDest string = path.Join("etc", "systemd", "system", "kubelet.service.d", "10-kubeadm.conf")
-
-	// systemdUnitDir  string = path.Join(gopath, "src", "k8s.io", "kubernetes", "build", "debs")
-	// systemdUnitDest string = path.Join("usr", "lib", "systemd", "system")
+	goPath  string = os.Getenv("GOPATH")
+	cniPath string = os.Getenv("CNI_PATH")
 )
 
 var k8sbinds []string
@@ -63,7 +52,7 @@ var defaultBinds = []string{
 	bindro + parseBind("$PWD/etc/docker_20-kubeadm-extra-args.conf:/etc/systemd/system/docker.service.d/20-kubeadm-extra-args.conf"),
 	bindro + parseBind("$PWD/etc/kube_20-kubeadm-extra-args.conf:/etc/systemd/system/kubelet.service.d/20-kubeadm-extra-args.conf"),
 	// cni bins
-	bindrw + path.Join(cnipath+":/opt/cni/bin"),
+	bindrw + path.Join(cniPath+":/opt/cni/bin"),
 }
 
 func parseBind(bindstring string) string {
@@ -96,12 +85,12 @@ func RunNode(k8srelease, name string) error {
 	} else {
 		k8sbinds = []string{
 			// bins
-			bindro + path.Join(gopath, "/src/k8s.io/kubernetes/_output/bin/kubelet:/usr/bin/kubelet"),
-			bindro + path.Join(gopath, "/src/k8s.io/kubernetes/_output/bin/kubeadm:/usr/bin/kubeadm"),
-			bindro + path.Join(gopath, "/src/k8s.io/kubernetes/_output/bin/kubectl:/usr/bin/kubectl"),
+			bindro + path.Join(goPath, "/src/k8s.io/kubernetes/_output/bin/kubelet:/usr/bin/kubelet"),
+			bindro + path.Join(goPath, "/src/k8s.io/kubernetes/_output/bin/kubeadm:/usr/bin/kubeadm"),
+			bindro + path.Join(goPath, "/src/k8s.io/kubernetes/_output/bin/kubectl:/usr/bin/kubectl"),
 			// service files
-			bindro + path.Join(gopath, "/src/k8s.io/kubernetes/build/debs/kubelet.service:/usr/lib/systemd/system/kubelet.service"),
-			bindro + path.Join(gopath, "/src/k8s.io/release/rpm/10-kubeadm.conf:/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"),
+			bindro + path.Join(goPath, "/src/k8s.io/kubernetes/build/debs/kubelet.service:/usr/lib/systemd/system/kubelet.service"),
+			bindro + path.Join(goPath, "/src/k8s.io/release/rpm/10-kubeadm.conf:/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"),
 		}
 	}
 	args = append(args, k8sbinds...)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+)
+
+var (
+	homePath string = os.Getenv("HOME")
+	goPath   string = os.Getenv("GOPATH")
+	cniPath  string = os.Getenv("CNI_PATH")
+)
+
+func checkValidDir(inPath string) error {
+	if fi, err := os.Stat(inPath); os.IsNotExist(err) {
+		return err
+	} else if !fi.IsDir() {
+		return fmt.Errorf("%q is not a directory.")
+	}
+	return nil
+}
+
+func GetValidGoPath() (string, error) {
+	if err := checkValidDir(goPath); err != nil {
+		// fall back to $HOME/go
+		goPathOrig := goPath
+		goPath = path.Join(homePath, "go")
+		log.Printf("invalid GOPATH %q, fall back to %s...\n", goPathOrig, goPath)
+		if err := checkValidDir(goPath); err != nil {
+			return "", err
+		}
+	}
+
+	return goPath, nil
+}
+
+func GetValidCniPath(inGoPath string) (string, error) {
+	if err := checkValidDir(cniPath); err != nil {
+		// fall back to $GOPATH/bin
+		cniPathOrig := cniPath
+		cniPath = path.Join(inGoPath, "bin")
+		log.Printf("invalid CNI_PATH %q, fall back to %s...\n", cniPathOrig, cniPath)
+		if err := checkValidDir(cniPath); err != nil {
+			return "", err
+		}
+	}
+
+	return cniPath, nil
+}


### PR DESCRIPTION
Check for availability of `$GOPATH` and `$CNI_PATH` in a flexible way. If a given path is not a valid path to a directory, fall back to the next possible path candidate. If it still fails, print out warning. That way, users could get chances to fix the paths.

Partly covers https://github.com/kinvolk/kube-spawn/issues/81
