### PR TITLE
pkg/bootstrap: check if there's enough space in storage volume

### DIFF
--- a/cmd/kube-spawn/setup.go
+++ b/cmd/kube-spawn/setup.go
@@ -118,6 +118,14 @@ func doSetup(numNodes int, baseImage string) {
 		log.Fatalf("Error downloading socat files: %s", err)
 	}
 
+	// estimate get pool size based on sum of virtual image sizes.
+	var poolSize int64
+	var err error
+	if poolSize, err = bootstrap.GetPoolSize(baseImage, numNodes); err != nil {
+		// fail hard in case of error, to avoid running unnecessary nodes
+		log.Fatalf("cannot get pool size: %v", err)
+	}
+
 	var nodesToRun []string
 
 	for i := 0; i < numNodes; i++ {
@@ -137,14 +145,8 @@ func doSetup(numNodes int, baseImage string) {
 		os.Exit(1)
 	}
 
-	var poolSize int64
-	var err error
-	if poolSize, err = bootstrap.GetPoolSize(baseImage, len(nodesToRun)); err != nil {
-		log.Printf("cannot get pool size: %v", err)
-	} else {
-		if err := bootstrap.EnlargeStoragePool(poolSize); err != nil {
-			log.Printf("Warning: cannot enlarge storage pool: %v", err)
-		}
+	if err := bootstrap.EnlargeStoragePool(poolSize); err != nil {
+		log.Printf("Warning: cannot enlarge storage pool: %v", err)
 	}
 
 	for _, name := range nodesToRun {

--- a/cmd/kube-spawn/setup.go
+++ b/cmd/kube-spawn/setup.go
@@ -137,8 +137,14 @@ func doSetup(numNodes int, baseImage string) {
 		os.Exit(1)
 	}
 
-	if err := bootstrap.EnlargeStoragePool(baseImage, len(nodesToRun)); err != nil {
-		log.Printf("Warning: cannot enlarge storage pool: %s", err)
+	var poolSize int64
+	var err error
+	if poolSize, err = bootstrap.GetPoolSize(baseImage, len(nodesToRun)); err != nil {
+		log.Printf("cannot get pool size: %v", err)
+	} else {
+		if err := bootstrap.EnlargeStoragePool(poolSize); err != nil {
+			log.Printf("Warning: cannot enlarge storage pool: %v", err)
+		}
 	}
 
 	for _, name := range nodesToRun {

--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -214,7 +214,8 @@ func GetPoolSize(baseImage string, nodes int) (int64, error) {
 	// We should reserve some unallocated free space for the whole host,
 	// as 100% usage of rootfs could badly affect the system's reliability.
 	if extraSize >= int64((float64(freeVolSpace))*0.9) {
-		return 0, fmt.Errorf("no more free space in %s. Please get more space!", varDir)
+		biSizeMB := int64(biSize / 1024 / 1024)
+		return 0, fmt.Errorf("not enough space on disk for %d nodes, Each node needs about %d MB, so in total you'll need about %d MB available.", nodes, biSizeMB, int64(nodes)*biSizeMB)
 	}
 
 	poolSize += extraSize

--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -178,8 +178,9 @@ func IsNodeRunning(nodeName string) bool {
 	return false
 }
 
-func EnlargeStoragePool(baseImage string, nodes int) error {
-	var poolSize int64 // in bytes
+func GetPoolSize(baseImage string, nodes int) (int64, error) {
+	var poolSize int64  // in bytes
+	var extraSize int64 // in bytes
 
 	// Give 50% more space for each cloned image.
 	// NOTE: this is just a workaround, as how much space we should add more
@@ -193,30 +194,54 @@ func EnlargeStoragePool(baseImage string, nodes int) error {
 
 	fipool, err := os.Stat(machinesImage)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	poolSize = fipool.Size()
 
-	poolSize += int64(float64(fipool.Size()) * extraSizeRatio)
+	extraSize = int64(float64(fipool.Size()) * extraSizeRatio)
 
 	fiBase, err := os.Stat(baseImageAbspath)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	poolSize += int64(float64(fiBase.Size())*extraSizeRatio) * int64(nodes)
+	extraSize += int64(float64(fiBase.Size())*extraSizeRatio) * int64(nodes)
 
+	varDir, _ := path.Split(machinesImage)
+	freeVolSpace, err := getVolFreeSpace(varDir)
+	if err != nil {
+		return 0, err
+	}
+
+	// extraSize, space to be allocated, shoud be 90% of freeVolSpace,
+	// actual free space on the target volume. Here 90% is simply a
+	// pre-defined estimation of how much space can be occupied.
+	// We should reserve some unallocated free space for the whole host,
+	// as 100% usage of rootfs could badly affect the system's reliability.
+	if extraSize >= int64((float64(freeVolSpace))*0.9) {
+		return 0, fmt.Errorf("no more free space in %s. Please get more space!", varDir)
+	}
+
+	poolSize += extraSize
+
+	return poolSize, nil
+}
+
+func EnlargeStoragePool(poolSize int64) error {
 	// It is equivalent to the following shell commands:
 	//  # umount /var/lib/machines
 	//  # qemu-img resize -f raw /var/lib/machines.raw <poolsize>
 	//  # mount -t btrfs -o loop /var/lib/machines.raw /var/lib/machines
 	//  # btrfs filesystem resize max /var/lib/machines
 	//  # btrfs quota disable /var/lib/machines
-	if err := syscall.Unmount(machinesDir, 0); err != nil {
-		// if it's already unmounted, umount(2) returns EINVAL, then continue
-		if !os.IsNotExist(err) && err != syscall.EINVAL {
-			return err
+	if err := checkMountpoint(machinesDir); err == nil {
+		// It means machinesDir is mountpoint, so do unmount
+		if err := syscall.Unmount(machinesDir, 0); err != nil {
+			// if it's already unmounted, umount(2) returns EINVAL, then continue
+			if !os.IsNotExist(err) && err != syscall.EINVAL {
+				return err
+			}
 		}
 	}
 

--- a/pkg/bootstrap/util.go
+++ b/pkg/bootstrap/util.go
@@ -128,3 +128,20 @@ func getVolFreeSpace(volPath string) (uint64, error) {
 
 	return freeSpace, nil
 }
+
+// get allocated size of file (in bytes)
+func getAllocatedFileSize(filename string) (int64, error) {
+	fi, err := os.Stat(filename)
+	if err != nil {
+		return 0, err
+	}
+
+	stat_t, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("cannot determine allocated filesize")
+	}
+
+	// stat(2) returns allocated filesize in blocks, each of which is
+	// a fixed 512 bytes
+	return (stat_t.Blocks * 512), nil
+}

--- a/pkg/bootstrap/util.go
+++ b/pkg/bootstrap/util.go
@@ -1,8 +1,26 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bootstrap
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"path/filepath"
 	"syscall"
 	"unsafe"
 )
@@ -75,4 +93,38 @@ func PathSupportsOverlay(path string) error {
 	}
 
 	return nil
+}
+
+func isSameFilesystem(a, b *syscall.Statfs_t) bool {
+	return a.Fsid == b.Fsid
+}
+
+func checkMountpoint(dir string) error {
+	sfs1 := &syscall.Statfs_t{}
+	if err := syscall.Statfs(dir, sfs1); err != nil {
+		return fmt.Errorf("error calling statfs on %q: %v", dir, err)
+	}
+	sfs2 := &syscall.Statfs_t{}
+	if err := syscall.Statfs(filepath.Dir(dir), sfs2); err != nil {
+		return fmt.Errorf("error calling statfs on %q: %v", dir, err)
+	}
+	if isSameFilesystem(sfs1, sfs2) {
+		return fmt.Errorf("%q is not a mount point", dir)
+	}
+
+	return nil
+}
+
+// get free space of volume mounted on volPath (in bytes)
+func getVolFreeSpace(volPath string) (uint64, error) {
+	var stat syscall.Statfs_t
+
+	if err := syscall.Statfs(volPath, &stat); err != nil {
+		log.Printf("statfs error: %v\n", err)
+		return 0, err
+	}
+
+	freeSpace := stat.Bavail * uint64(stat.Bsize)
+
+	return freeSpace, nil
 }


### PR DESCRIPTION
Before enlarging storage volume, we should first check if the additional volume size would make the whole storage volume full. If that might be the case, we should not enlarge the volume, and print warning to users.

Possibly resolves https://github.com/kinvolk/kube-spawn/issues/85