### PR TITLE
bootstrap, nspawntool: mount .kube-spawn into /var/lib/docker

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,8 @@ Vagrant.configure("2") do |config|
       create: true,
       owner: "vagrant",
       group: "vagrant",
-      type: "rsync"
+      type: "rsync",
+      rsync__exclude: ".kube-spawn/"
 
     # NOTE: chown is explicitly needed, even when synced_folder is configured
     # with correct owner/group. Maybe a vagrant issue?
@@ -47,7 +48,8 @@ Vagrant.configure("2") do |config|
       create: true,
       owner: "ubuntu",
       group: "ubuntu",
-      type: "rsync"
+      type: "rsync",
+      rsync__exclude: ".kube-spawn/"
 
     config.vm.provision "shell", inline: "mkdir -p /home/ubuntu/go ; chown -R ubuntu:ubuntu /home/ubuntu/go"
     config.vm.provision "shell", env: {"GOPATH" => "/home/ubuntu/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
@@ -64,7 +66,8 @@ Vagrant.configure("2") do |config|
       create: true,
       owner: "vagrant",
       group: "vagrant",
-      type: "rsync"
+      type: "rsync",
+      rsync__exclude: ".kube-spawn/"
 
     config.vm.provision "shell", inline: "mkdir -p /home/vagrant/go ; chown -R vagrant:vagrant /home/vagrant/go"
     config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"

--- a/cmd/kube-spawn/setup.go
+++ b/cmd/kube-spawn/setup.go
@@ -28,8 +28,9 @@ import (
 )
 
 var (
-	numNodes  int
-	baseImage string
+	numNodes     int
+	baseImage    string
+	kubeSpawnDir string
 
 	cmdSetup = &cobra.Command{
 		Use:   "setup",
@@ -43,6 +44,7 @@ func init() {
 
 	cmdSetup.Flags().IntVarP(&numNodes, "nodes", "n", 1, "number of nodes to spawn")
 	cmdSetup.Flags().StringVarP(&baseImage, "image", "i", "", "base image for nodes")
+	cmdSetup.Flags().StringVarP(&kubeSpawnDir, "kube-spawn-dir", "d", "", "path to .kube-spawn directory")
 }
 
 func checkK8sStableRelease(k8srel string) bool {
@@ -127,7 +129,7 @@ func doSetup(numNodes int, baseImage string) {
 	}
 
 	for _, name := range nodesToRun {
-		if err := nspawntool.RunNode(k8srelease, name); err != nil {
+		if err := nspawntool.RunNode(k8srelease, name, kubeSpawnDir); err != nil {
 			log.Fatalf("Error running node: %s", err)
 		}
 

--- a/pkg/bootstrap/util.go
+++ b/pkg/bootstrap/util.go
@@ -1,8 +1,17 @@
 package bootstrap
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
 
-const tmpDir string = "tmp"
+const (
+	tmpDir      string = "tmp"
+	FsMagicAUFS        = 0x61756673 // https://goo.gl/CBwx43
+	FsMagicZFS         = 0x2FC12FC1 // https://goo.gl/xTvzO5
+)
 
 func CreateSharedTmpdir() {
 	if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
@@ -12,4 +21,58 @@ func CreateSharedTmpdir() {
 		// 	return err
 		// }
 	}
+}
+
+// PathSupportsOverlay checks whether the given path is compatible with OverlayFS.
+// This method also calls isOverlayfsAvailable().
+// It returns error if OverlayFS is not supported.
+//  - taken from https://github.com/rkt/rkt/blob/master/common/common.go
+func PathSupportsOverlay(path string) error {
+	if !isOverlayfsAvailable() {
+		return fmt.Errorf("overlayfs is not available")
+	}
+
+	var data syscall.Statfs_t
+	if err := syscall.Statfs(path, &data); err != nil {
+		return fmt.Errorf("cannot statfs %q", path)
+	}
+
+	switch data.Type {
+	case FsMagicAUFS:
+		return fmt.Errorf("unsupported filesystem: aufs")
+	case FsMagicZFS:
+		return fmt.Errorf("unsupported filesystem: zfs")
+	}
+
+	dir, err := os.OpenFile(path, syscall.O_RDONLY|syscall.O_DIRECTORY, 0755)
+	if err != nil {
+		return fmt.Errorf("cannot open %q", path)
+	}
+	defer dir.Close()
+
+	buf := make([]byte, 4096)
+	// ReadDirent forwards to the raw syscall getdents(3),
+	// passing the buffer size.
+	n, err := syscall.ReadDirent(int(dir.Fd()), buf)
+	if err != nil {
+		return fmt.Errorf("cannot read directory %q", path)
+	}
+
+	offset := 0
+	for offset < n {
+		// offset overflow cannot happen, because Reclen
+		// is being maintained by getdents(3), considering the buffer size.
+		dirent := (*syscall.Dirent)(unsafe.Pointer(&buf[offset]))
+		offset += int(dirent.Reclen)
+
+		if dirent.Ino == 0 { // File absent in directory.
+			continue
+		}
+
+		if dirent.Type == syscall.DT_UNKNOWN {
+			return fmt.Errorf("unsupported filesystem: missing d_type support")
+		}
+	}
+
+	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -29,7 +29,7 @@ var (
 	cniPath  string = os.Getenv("CNI_PATH")
 )
 
-func checkValidDir(inPath string) error {
+func CheckValidDir(inPath string) error {
 	if fi, err := os.Stat(inPath); os.IsNotExist(err) {
 		return err
 	} else if !fi.IsDir() {
@@ -39,12 +39,12 @@ func checkValidDir(inPath string) error {
 }
 
 func GetValidGoPath() (string, error) {
-	if err := checkValidDir(goPath); err != nil {
+	if err := CheckValidDir(goPath); err != nil {
 		// fall back to $HOME/go
 		goPathOrig := goPath
 		goPath = path.Join(homePath, "go")
 		log.Printf("invalid GOPATH %q, fall back to %s...\n", goPathOrig, goPath)
-		if err := checkValidDir(goPath); err != nil {
+		if err := CheckValidDir(goPath); err != nil {
 			return "", err
 		}
 	}
@@ -53,12 +53,12 @@ func GetValidGoPath() (string, error) {
 }
 
 func GetValidCniPath(inGoPath string) (string, error) {
-	if err := checkValidDir(cniPath); err != nil {
+	if err := CheckValidDir(cniPath); err != nil {
 		// fall back to $GOPATH/bin
 		cniPathOrig := cniPath
 		cniPath = path.Join(inGoPath, "bin")
 		log.Printf("invalid CNI_PATH %q, fall back to %s...\n", cniPathOrig, cniPath)
-		if err := checkValidDir(cniPath); err != nil {
+		if err := CheckValidDir(cniPath); err != nil {
 			return "", err
 		}
 	}


### PR DESCRIPTION
Mount `.kube-spawn/default/MACHINE_NAME/mount` into `/var/lib/docker` on `MACHINE_NAME`. For example, `.kube-spawn/default/kube-spawn-0/mount` into `/var/lib/docker` on `kube-spawn-0`. Then the docker volume can be handled from rootfs on the host, and we could avoid most of storage issues.

Downside with the scenario is that rootfs on the host must be a filesystem that supports overlayfs. For example ext4 does support overlayfs, while others don't. If the host rootfs is non-supported filesystem, print out error and exit, so that users can run `"setup"` with an option `"--kube-spawn-dir=OTHER_DIR"`, where `OTHER_DIR` is ext4.

Fixes https://github.com/kinvolk/kube-spawn/issues/88
