### PR TITLE
nspawntool: create .kube-spawn directory before PathSupportsOverlay()

### DIFF
--- a/cmd/kube-spawn/setup.go
+++ b/cmd/kube-spawn/setup.go
@@ -44,7 +44,7 @@ func init() {
 
 	cmdSetup.Flags().IntVarP(&numNodes, "nodes", "n", 1, "number of nodes to spawn")
 	cmdSetup.Flags().StringVarP(&baseImage, "image", "i", "", "base image for nodes")
-	cmdSetup.Flags().StringVarP(&kubeSpawnDir, "kube-spawn-dir", "d", "", "path to .kube-spawn directory")
+	cmdSetup.Flags().StringVarP(&kubeSpawnDir, "kube-spawn-dir", "d", "", "path to directory where .kube-spawn directory is located")
 }
 
 func checkK8sStableRelease(k8srel string) bool {

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -70,7 +70,7 @@ func parseBind(bindstring string) string {
 	return strings.Replace(bindstring, "$PWD", pwd, 1)
 }
 
-func RunNode(k8srelease, name, kubeSpawnDir string) error {
+func RunNode(k8srelease, name, kubeSpawnDirParent string) error {
 	var err error
 
 	if goPath, err = utils.GetValidGoPath(); err != nil {
@@ -84,11 +84,12 @@ func RunNode(k8srelease, name, kubeSpawnDir string) error {
 	// defaultBinds has to be determined after evaluation of cniPath
 	defaultBinds = getDefaultBinds(cniPath)
 
-	if kubeSpawnDir == "" {
-		kubeSpawnDir = parseBind("$PWD/.kube-spawn")
-	} else if err := utils.CheckValidDir(kubeSpawnDir); err != nil {
-		kubeSpawnDir = parseBind("$PWD/.kube-spawn")
+	if kubeSpawnDirParent == "" {
+		kubeSpawnDirParent = parseBind("$PWD")
+	} else if err := utils.CheckValidDir(kubeSpawnDirParent); err != nil {
+		kubeSpawnDirParent = parseBind("$PWD")
 	}
+	kubeSpawnDir := path.Join(kubeSpawnDirParent, ".kube-spawn")
 
 	if err := os.MkdirAll(kubeSpawnDir, os.FileMode(0755)); err != nil {
 		return fmt.Errorf("unable to create directory %q: %v.", kubeSpawnDir, err)

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -90,6 +90,10 @@ func RunNode(k8srelease, name, kubeSpawnDir string) error {
 		kubeSpawnDir = parseBind("$PWD/.kube-spawn")
 	}
 
+	if err := os.MkdirAll(kubeSpawnDir, os.FileMode(0755)); err != nil {
+		return fmt.Errorf("unable to create directory %q: %v.", kubeSpawnDir, err)
+	}
+
 	if err := bootstrap.PathSupportsOverlay(kubeSpawnDir); err != nil {
 		return fmt.Errorf("unable to create overlayfs on %q: %v. Try to pass a directory with a different filesystem (like ext4 or XFS) to --kube-spawn-dir.", kubeSpawnDir, err)
 	}


### PR DESCRIPTION
Create `.kube-spawn` directory before running `PathSupportsOverlay()`, otherwise it would fail if the directory doesn't exist.

Also let the `kube-spawn --kube-spawn-dir=` take parent directory of `.kube-spawn`. For example, `"kube-spawn setup --kube-spawn-dir=/home/user"` should create a directory `"/home/user/.kube-spawn"`.

Fixes https://github.com/kinvolk/kube-spawn/issues/92