### PR TITLE
Revert "kube-spawn-runc: don't set Std{err,out,in}"

### DIFF
--- a/cmd/kube-spawn-runc/kube-spawn-runc.go
+++ b/cmd/kube-spawn-runc/kube-spawn-runc.go
@@ -59,6 +59,9 @@ func main() {
 		}
 	}
 	cmd := exec.Command(runcPath, newArgs...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
 	if err := cmd.Run(); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This reverts commit aa6486f8a03105bdf7c4de16de5d280ffd78ffe8.

It was preventing logs to work. I tested this and it works now.