### PR TITLE
kube-spawn: ensure requirements also before running setup

### DIFF
--- a/cmd/kube-spawn/setup.go
+++ b/cmd/kube-spawn/setup.go
@@ -96,6 +96,7 @@ func doSetup(numNodes int, baseImage string) {
 	}
 
 	bootstrap.CreateSharedTmpdir()
+	bootstrap.EnsureRequirements()
 
 	doCheckK8sStableRelease(k8srelease)
 


### PR DESCRIPTION
As `setup` command gets usually called before `init`, we should also ensure requirements before running `setup`, to automatically load `overlay` and `nf_conntrack` modules.

Fixes https://github.com/kinvolk/kube-spawn/issues/97