### PR TITLE
pkg/nspawntool: add config to unmask weave interfaces

### DIFF
--- a/etc/weave_50-weave.network
+++ b/etc/weave_50-weave.network
@@ -1,0 +1,5 @@
+[Match]
+Name=weave datapath vethwe*
+
+[Link]
+Unmanaged=yes

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -57,6 +57,7 @@ func getDefaultBinds(cniPath string) []string {
 		bindro + parseBind("$PWD/etc/kubeadm.yml:/etc/kubeadm/kubeadm.yml"),
 		bindro + parseBind("$PWD/etc/docker_20-kubeadm-extra-args.conf:/etc/systemd/system/docker.service.d/20-kubeadm-extra-args.conf"),
 		bindro + parseBind("$PWD/etc/kube_20-kubeadm-extra-args.conf:/etc/systemd/system/kubelet.service.d/20-kubeadm-extra-args.conf"),
+		bindro + parseBind("$PWD/etc/weave_50-weave.network:/etc/systemd/network/50-weave.network"),
 		// cni bins
 		bindrw + path.Join(cniPath+":/opt/cni/bin"),
 	}


### PR DESCRIPTION
Inside nspawn containers, sometimes the `weave` bridge interface becomes `DOWN` all the time, and never becomes `UP` again, no interface gets attached to the bridge. This is a known issue with systemd-networkd on Container Linux: `weave`, `vethwe-bridge`, `vethwe*` interfaces become `UP` at boot-time, but afterwards they become reconfigured by networkd again, so that `vethwe*` disappear and `vethwe-bridge` gets detached.

So we should make these interfaces `Unmanaged`, so that they cannot be reconfigured by networkd.

Fixes https://github.com/kinvolk/kube-spawn/issues/99