### PR TITLE
pkg/nspawntool: move tmp directory into .kube-spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,17 @@ $ sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=dev
 
 ## Deploying to your local cluster
 
-`kube-spawn` creates `tmp/` inside the directory you run it in.
+`kube-spawn` creates `.kube-spawn/default/` inside the directory you run it in.
 There you can find the `kubeconfig` for the cluster and a `token` file with
 a `kubeadm` token, that can be used to join more nodes.
 
 To verify everything worked you can run:
 ```
-$ kubectl --kubeconfig ./tmp/kubeconfig get nodes
+$ export KUBECONFIG=$HOME/go/src/github.com/kinvolk/kube-spawn/.kube-spawn/default/kubeconfig
+$ kubectl get nodes
 
 
-$ kubectl --kubeconfig ./tmp/kubeconfig create -f 'https://github.com/kubernetes/kubernetes/blob/master/examples/guestbook/all-in-one/frontend.yaml'
+$ kubectl create -f 'https://github.com/kubernetes/kubernetes/blob/master/examples/guestbook/all-in-one/frontend.yaml'
 ```
 
 ## Command Usage

--- a/pkg/bootstrap/util.go
+++ b/pkg/bootstrap/util.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	tmpDir      string = "tmp"
+	tmpDir      string = ".kube-spawn/default"
 	FsMagicAUFS        = 0x61756673 // https://goo.gl/CBwx43
 	FsMagicZFS         = 0x2FC12FC1 // https://goo.gl/xTvzO5
 )

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -51,7 +51,7 @@ func getDefaultBinds(cniPath string) []string {
 		bindrw + parseBind("$PWD/scripts:/opt/kube-spawn"),
 		bindro + parseBind("$PWD/kube-spawn-runc:/opt/kube-spawn-runc"),
 		// shared tmpdir
-		bindrw + parseBind("$PWD/tmp:/tmp/kube-spawn"),
+		bindrw + parseBind("$PWD/.kube-spawn/default:/tmp/kube-spawn"),
 		// extra configs
 		bindro + parseBind("$PWD/etc/daemon.json:/etc/docker/daemon.json"),
 		bindro + parseBind("$PWD/etc/kubeadm.yml:/etc/kubeadm/kubeadm.yml"),


### PR DESCRIPTION
Now that kube-spawn automatically creates `.kube-spawn` under `$PWD`, we should move `tmp` directory to `.kube-spawn/default`.

Change documents as well to recommend using `$KUBECONFIG` instead of long command-line options.

See also https://github.com/kinvolk/kube-spawn/pull/96#discussion_r129821464