### PR TITLE
kube-spawn-runc: selectively pass Stdout/Stderr before running command

### DIFF
--- a/cmd/kube-spawn-runc/kube-spawn-runc.go
+++ b/cmd/kube-spawn-runc/kube-spawn-runc.go
@@ -20,6 +20,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
+
+	"github.com/kinvolk/kube-spawn/pkg/utils"
 )
 
 var (
@@ -59,6 +61,16 @@ func main() {
 		}
 	}
 	cmd := exec.Command(runcPath, newArgs...)
+
+	// Selectively pass Stdout/Stderr, by determining if they are terminal or not.
+	// If we always pass them, interactive mode of connection to containers
+	// will fail with error messages like "container not started".
+	// If we never pass them, then "kubectl logs" won't be able to print any logs.
+	if !utils.IsTerminal(os.Stdout.Fd()) && !utils.IsTerminal(os.Stderr.Fd()) {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+
 	if err := cmd.Run(); err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -21,6 +21,10 @@ import (
 	"log"
 	"os"
 	"path"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -64,4 +68,11 @@ func GetValidCniPath(inGoPath string) (string, error) {
 	}
 
 	return cniPath, nil
+}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := unix.Syscall(unix.SYS_IOCTL, fd, uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&termios)))
+	return err == 0
 }


### PR DESCRIPTION
Selectively pass Stdout/Stderr, by determining if they are terminal or not, with help of ioctl with `syscall.TCGETS`.

If we would always pass them, interactive mode of connection to containers will fail with error messages like `"container not started"`. If we would not pass them at all, then `"kubectl logs"` would not be able to print any logs.

Suggested by @iaguis
Supersedes https://github.com/kinvolk/kube-spawn/pull/98