### PR TITLE
kube-spawn, bootstrap: include static binary of socat in containers

### DIFF
--- a/cmd/kube-spawn/setup.go
+++ b/cmd/kube-spawn/setup.go
@@ -106,6 +106,18 @@ func doSetup(numNodes int, baseImage string) {
 		}
 	}
 
+	// NOTE: workaround for making kubelet work with port-forward.
+	// Ideally we should solve the port-forward issue by either
+	// creating general add-ons based on torcx, or creating our own
+	// container image, or at least building socat statically on our own.
+	ksExtraDir := ".kube-spawn/extras"
+	if err := os.MkdirAll(ksExtraDir, os.FileMode(0755)); err != nil {
+		log.Fatalf("Unable to create directory %q: %v.", ksExtraDir, err)
+	}
+	if err := bootstrap.DownloadSocatBin(ksExtraDir); err != nil {
+		log.Fatalf("Error downloading socat files: %s", err)
+	}
+
 	var nodesToRun []string
 
 	for i := 0; i < numNodes; i++ {

--- a/pkg/bootstrap/kubernetes.go
+++ b/pkg/bootstrap/kubernetes.go
@@ -7,12 +7,14 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
 const (
-	k8sURL       string = "https://dl.k8s.io/v$VERSION/bin/linux/amd64/"
-	k8sGithubURL string = "https://raw.githubusercontent.com/kubernetes/release/master/rpm/"
+	k8sURL         string = "https://dl.k8s.io/v$VERSION/bin/linux/amd64/"
+	k8sGithubURL   string = "https://raw.githubusercontent.com/kubernetes/release/master/rpm/"
+	staticSocatUrl string = "https://raw.githubusercontent.com/andrew-d/static-binaries/master/binaries/linux/x86_64/socat"
 )
 
 var (
@@ -71,5 +73,30 @@ func DownloadK8sBins(version, dir string) error {
 		}
 		fd.Close()
 	}
+	return nil
+}
+
+func DownloadSocatBin(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		os.MkdirAll(dir, os.ModePerm)
+	}
+
+	var fd *os.File
+	fpath := filepath.Join(dir, path.Base(staticSocatUrl))
+
+	if _, err := os.Stat(fpath); os.IsNotExist(err) {
+		log.Printf("%s downloading...\n", fpath)
+		fd, err = Download(staticSocatUrl, fpath)
+		if err != nil {
+			return fmt.Errorf("error downloading %s: %s", staticSocatUrl, err)
+		}
+	} else {
+		log.Printf("%s already downloaded, skipping...\n", fpath)
+		fd, err = os.Open(fpath)
+		if err != nil {
+			return fmt.Errorf("error opening %s: %s", fpath, err)
+		}
+	}
+	fd.Close()
 	return nil
 }

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -138,6 +138,9 @@ func RunNode(k8srelease, name, kubeSpawnDirParent string) error {
 	}
 	args = append(args, k8sbinds...)
 
+	// NOTE: workaround for making kubelet work with port-forward
+	args = append(args, bindro+parseBind("$PWD/.kube-spawn/extras/socat:/usr/bin/socat"))
+
 	c := exec.Cmd{
 		Path:   "cnispawn",
 		Args:   args,


### PR DESCRIPTION
To be able to make kubelet's port-forward work, download static binary of `socat` to be installed under `/opt/bin/`.
This is workaround for now. In the future we need to find a proper solution for the issue.

Fixes https://github.com/kinvolk/kube-spawn/issues/105