### PR TITLE
pkg/bootstrap: allow CNI traffic, disable SELinux enforcing mode

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -10,14 +10,12 @@ If any path-related problem still occurs, please try the following approaches:
 * try to run with `sudo -E kube-spawn ...` to pass normal-user's env variables
 * try to run with pre-defined `GOPATH` or `CNI_PATH`, for example `sudo GOPATH=/home/myuser/go CNI_PATH=/home/myuser/go/bin kube-spawn ...`
 
-## SELinux and firewalld
+## SELinux
 
-To run `kube-spawn`, it is recommended to turn off SELinux enforcing mode as well as to stop firewalld:
+To run `kube-spawn`, it is recommended to turn off SELinux enforcing mode:
 
 ```
 $ sudo setenforce 0
-$ sudo systemctl stop firewalld.service
-$ sudo iptables -P FORWARD ACCEPT
 ```
 
 However, it is also true that disabling security framework is not always desirable. So it is planned to handle security policy instead of disabling them. Until then, there's no easy way to get around.

--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -381,7 +381,9 @@ func EnsureRequirements() {
 	ensureOverlayfs()
 	ensureConntrackHashsize()
 
-	// TODO: handle SELinux as well as firewalld
+	// insert an iptables rules to allow traffic through cni0
+	ensureIptables()
+	// TODO: handle SELinux
 }
 
 func isOverlayfsAvailable() bool {
@@ -504,5 +506,125 @@ func ensureConntrackHashsize() {
 	if err := setConntrackHashsize(); err != nil {
 		log.Printf("error setting conntrack hashsize: %v\n", err)
 		return
+	}
+}
+
+func setIptablesForwardPolicy() error {
+	var cmdPath string
+	var err error
+
+	log.Println("making iptables FORWARD chain defaults to ACCEPT...")
+
+	if cmdPath, err = exec.LookPath("iptables"); err != nil {
+		// fall back to an ordinary abspath
+		cmdPath = "/sbin/iptables"
+	}
+
+	// set the default policy for FORWARD chain to ACCEPT
+	// : iptables -P FORWARD ACCEPT
+	args := []string{
+		cmdPath,
+		"-P",
+		"FORWARD",
+		"ACCEPT",
+	}
+
+	cmd := exec.Cmd{
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isCniRuleLoaded() bool {
+	var cmdPath string
+	var err error
+
+	if cmdPath, err = exec.LookPath("iptables"); err != nil {
+		// fall back to an ordinary abspath
+		cmdPath = "/sbin/iptables"
+	}
+
+	// check if a cni iptables rules already exists
+	// : iptables -C FORWARD -i cni0 -j ACCEPT
+	args := []string{
+		cmdPath,
+		"-C",
+		"FORWARD",
+		"-i",
+		"cni0",
+		"-j",
+		"ACCEPT",
+	}
+
+	cmd := exec.Cmd{
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+	}
+
+	if err := cmd.Run(); err != nil {
+		// error means that the rule does not exist
+		return false
+	}
+
+	return true
+}
+
+func setAllowCniRule() error {
+	var cmdPath string
+	var err error
+
+	if cmdPath, err = exec.LookPath("iptables"); err != nil {
+		// fall back to an ordinary abspath
+		cmdPath = "/sbin/iptables"
+	}
+
+	// insert an iptables rules to allow traffic through cni0
+	// : iptables -I FORWARD 1 -i cni0 -j ACCEPT
+	args := []string{
+		cmdPath,
+		"-I",
+		"FORWARD",
+		"1",
+		"-i",
+		"cni0",
+		"-j",
+		"ACCEPT",
+	}
+
+	cmd := exec.Cmd{
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ensureIptables() {
+	setIptablesForwardPolicy()
+
+	if !isCniRuleLoaded() {
+		log.Println("setting iptables rule to allow CNI traffic...")
+		if err := setAllowCniRule(); err != nil {
+			log.Printf("error running iptables: %v\n", err)
+			return
+		}
 	}
 }

--- a/scripts/vagrant-mod-env.sh
+++ b/scripts/vagrant-mod-env.sh
@@ -27,10 +27,11 @@ chmod +x ${HOME}/build.sh
 # we should ignore the error and continue.
 /usr/sbin/setenforce 0 || true
 
-# Stop firewalld to allow traffic by default.
-# Note that especially on Debian systems, it's not sufficient to stop
-# firewalld, because the FORWARD chain's policy is still DROP.
-systemctl is-active firewalld 1>/dev/null && systemctl stop firewalld
+# Run iptables to allow CNI traffic by default.
+iptables -C FORWARD -i cni0 -j ACCEPT 2>/dev/null || iptables -I FORWARD 1 -i cni0 -j ACCEPT
+
+# Note that especially on Debian systems, it's not sufficient to add
+# a single iptables rule, because the FORWARD chain's policy is still DROP.
 iptables -P FORWARD ACCEPT
 sysctl -w net.ipv4.ip_forward=1
 


### PR DESCRIPTION
Instead of stop firewall, we need to just allow traffic through CNI network interface `cni0`.
Also set the default policy of `FORWARD` chain to `ACCEPT`.

Though as for SELinux, we should automatically turn off the enforcing mode, as there's no way around multiple issues.

Fixes https://github.com/kinvolk/kube-spawn/issues/76