### PR TITLE
Fix message for kubeconfig, only log for runc when necessary

### DIFF
--- a/cmd/kube-spawn-runc/kube-spawn-runc.go
+++ b/cmd/kube-spawn-runc/kube-spawn-runc.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -41,7 +42,7 @@ func main() {
 		defer fd.Close()
 	}
 
-	log.Printf("old args: %#v", os.Args[1:])
+	printToLogpath(fmt.Sprintf("old args: %#v", os.Args[1:]))
 
 	for _, a := range os.Args[1:] {
 		newArgs = append(newArgs, a)
@@ -50,7 +51,7 @@ func main() {
 		}
 	}
 
-	log.Printf("new args: %#v", newArgs)
+	printToLogpath(fmt.Sprintf("new args: %#v", newArgs))
 
 	if runcPath == "" {
 		var err error
@@ -73,5 +74,12 @@ func main() {
 
 	if err := cmd.Run(); err != nil {
 		log.Fatal(err)
+	}
+}
+
+// print string only when logPath is explicitly set
+func printToLogpath(fmtStr string) {
+	if logPath != "" {
+		log.Printf("%s", fmtStr)
 	}
 }

--- a/cmd/kube-spawn/init.go
+++ b/cmd/kube-spawn/init.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
 	"github.com/kinvolk/kube-spawn/pkg/distribution"
 	"github.com/kinvolk/kube-spawn/pkg/nspawntool"
+	"github.com/kinvolk/kube-spawn/pkg/utils"
 )
 
 const pushImageRetries int = 10
@@ -94,5 +95,5 @@ func doInit() {
 		}
 	}
 
-	log.Println("Note: For kubectl to work, please set $KUBECONFIG to $HOME/go/src/github.com/kinvolk/kube-spawn/.kube-spawn/default/kubeconfig.")
+	log.Println("Note: For kubectl to work, please set $KUBECONFIG to " + utils.GetValidKubeConfig())
 }

--- a/cmd/kube-spawn/kube-spawn.go
+++ b/cmd/kube-spawn/kube-spawn.go
@@ -43,7 +43,6 @@ var (
 	}
 
 	version      string
-	gopath       string = os.Getenv("GOPATH")
 	k8srelease   string
 	printVersion bool
 )


### PR DESCRIPTION
Print args only when `logPath` (`$KUBE_SPAWN_RUNC_LOG_PATH`) is explicitly set. Otherwise the logs will appear at the top of every pod's log.

At the end of init command, print out message for setting `$KUBECONFIG` based on real lookups: first try `$PWD/.kube-spawn/default/kubeconfig`, then `$GOPATH/src/github.com/kinvolk/kube-spawn/.kube-spawn/default/kubeconfig`, then `$HOME/go/src/github.com/kinvolk/kube-spawn/.kube-spawn/default/kubeconfig`.

Fixes https://github.com/kinvolk/kube-spawn/issues/104 https://github.com/kinvolk/kube-spawn/issues/111