### PR TITLE
Fix a check for k8srelease and URL for gcr.io

### DIFF
--- a/cmd/kube-spawn/init.go
+++ b/cmd/kube-spawn/init.go
@@ -42,10 +42,6 @@ func init() {
 	cmdKubeSpawn.AddCommand(cmdInit)
 }
 
-func isDev(k8srel string) bool {
-	return k8srel == "" || k8srel == "dev"
-}
-
 func runInit(cmd *cobra.Command, args []string) {
 	doInit()
 }
@@ -53,7 +49,7 @@ func runInit(cmd *cobra.Command, args []string) {
 func doInit() {
 	doCheckK8sStableRelease(k8srelease)
 
-	if isDev(k8srelease) {
+	if utils.IsK8sDev(k8srelease) {
 		// we don't need to run a docker registry
 		if err := distribution.StartRegistry(); err != nil {
 			log.Fatalf("Error starting registry: %s", err)

--- a/cmd/kube-spawn/setup.go
+++ b/cmd/kube-spawn/setup.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
 	"github.com/kinvolk/kube-spawn/pkg/nspawntool"
+	"github.com/kinvolk/kube-spawn/pkg/utils"
 )
 
 var (
@@ -100,7 +101,7 @@ func doSetup(numNodes int, baseImage, kubeSpawnDir string) {
 
 	doCheckK8sStableRelease(k8srelease)
 
-	if !isDev(k8srelease) {
+	if !utils.IsK8sDev(k8srelease) {
 		if err := bootstrap.DownloadK8sBins(k8srelease, "./k8s"); err != nil {
 			log.Fatalf("Error downloading k8s files: %s", err)
 		}

--- a/etc/kube_20-kubeadm-extra-args-k8s18.conf
+++ b/etc/kube_20-kubeadm-extra-args-k8s18.conf
@@ -1,0 +1,7 @@
+[Service]
+Environment="KUBELET_EXTRA_ARGS=\
+--cgroup-driver=cgroupfs \
+--enforce-node-allocatable= \
+--cgroups-per-qos=false \
+--authentication-token-webhook \
+--fail-swap-on=false"

--- a/etc/kube_tmpfiles_kubelet.conf
+++ b/etc/kube_tmpfiles_kubelet.conf
@@ -1,0 +1,1 @@
+d /var/lib/kubelet 0755 - - -

--- a/etc/kubeadm.yml
+++ b/etc/kubeadm.yml
@@ -3,4 +3,5 @@ authorizationMode: AlwaysAllow
 apiServerExtraArgs:
   insecure-port: "8080"
 controllerManagerExtraArgs:
+kubernetesVersion: latest
 schedulerExtraArgs:

--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -110,7 +110,11 @@ func GetRunningNodes() ([]Node, error) {
 		//  kube-spawn-0 container systemd-nspawn
 
 		var ipaddr string
-		machineName := line[0]
+		machineName := strings.TrimSpace(line[0])
+		if !strings.HasPrefix(machineName, "kube-spawn-") {
+			continue
+		}
+
 		if len(line) >= 6 {
 			ipaddr = strings.TrimSuffix(line[5], "...")
 		} else {

--- a/pkg/distribution/registry.go
+++ b/pkg/distribution/registry.go
@@ -104,7 +104,7 @@ func PushImage() error {
 
 	if err := cli.ImageTag(
 		context.Background(),
-		"gcr.io/google_containers/hyperkube-amd64",
+		"gcr.io/google-containers/hyperkube-amd64",
 		"10.22.0.1:5000/hyperkube-amd64",
 	); err != nil {
 		return err

--- a/pkg/nspawntool/kubeadm.go
+++ b/pkg/nspawntool/kubeadm.go
@@ -4,13 +4,14 @@ import (
 	"os"
 
 	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
+	"github.com/kinvolk/kube-spawn/pkg/utils"
 )
 
 func InitializeMaster(k8srelease, name string) error {
 	cmd := []string{
 		"/opt/kube-spawn/init.sh",
 	}
-	if k8srelease != "" {
+	if !utils.IsK8sDev(k8srelease) {
 		cmd = []string{"/opt/kube-spawn/init-release.sh", "--version", k8srelease}
 	}
 	return bootstrap.Exec(nil, os.Stdout, os.Stderr, name, cmd...)
@@ -20,7 +21,7 @@ func JoinNode(k8srelease, name, masterIP string) error {
 	cmd := []string{
 		"/opt/kube-spawn/join.sh",
 	}
-	if k8srelease != "" {
+	if !utils.IsK8sDev(k8srelease) {
 		cmd = []string{"/opt/kube-spawn/join-release.sh"}
 	}
 	cmd = append(cmd, masterIP)

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -126,11 +127,15 @@ func RunNode(k8srelease, name, kubeSpawnDirParent string) error {
 			bindro + parseBind("$PWD/k8s/10-kubeadm.conf:/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"),
 		}
 	} else {
+		k8sOutputDir, err := utils.GetK8sBuildOutputDir(filepath.Join(goPath, "/src/k8s.io/kubernetes"))
+		if err != nil {
+			return fmt.Errorf("error getting k8s output directory: %s", err)
+		}
 		k8sbinds = []string{
 			// bins
-			bindro + path.Join(goPath, "/src/k8s.io/kubernetes/_output/bin/kubelet:/usr/bin/kubelet"),
-			bindro + path.Join(goPath, "/src/k8s.io/kubernetes/_output/bin/kubeadm:/usr/bin/kubeadm"),
-			bindro + path.Join(goPath, "/src/k8s.io/kubernetes/_output/bin/kubectl:/usr/bin/kubectl"),
+			bindro + path.Join(k8sOutputDir, "kubelet:/usr/bin/kubelet"),
+			bindro + path.Join(k8sOutputDir, "kubeadm:/usr/bin/kubeadm"),
+			bindro + path.Join(k8sOutputDir, "kubectl:/usr/bin/kubectl"),
 			// service files
 			bindro + path.Join(goPath, "/src/k8s.io/kubernetes/build/debs/kubelet.service:/usr/lib/systemd/system/kubelet.service"),
 			bindro + path.Join(goPath, "/src/k8s.io/release/rpm/10-kubeadm.conf:/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"),

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -115,7 +115,7 @@ func RunNode(k8srelease, name, kubeSpawnDirParent string) error {
 	args = append(args, defaultBinds...)
 
 	// TODO: we should have something like a "bind builder" that reuses code
-	if k8srelease != "" {
+	if !utils.IsK8sDev(k8srelease) {
 		k8sbinds = []string{
 			// bins
 			bindro + parseBind("$PWD/k8s/kubelet:/usr/bin/kubelet"),

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -58,6 +58,7 @@ func getDefaultBinds(cniPath string) []string {
 		bindro + parseBind("$PWD/etc/kubeadm.yml:/etc/kubeadm/kubeadm.yml"),
 		bindro + parseBind("$PWD/etc/docker_20-kubeadm-extra-args.conf:/etc/systemd/system/docker.service.d/20-kubeadm-extra-args.conf"),
 		bindro + parseBind("$PWD/etc/kube_20-kubeadm-extra-args.conf:/etc/systemd/system/kubelet.service.d/20-kubeadm-extra-args.conf"),
+		bindro + parseBind("$PWD/etc/kube_tmpfiles_kubelet.conf:/usr/lib/tmpfiles.d/kubelet.conf"),
 		bindro + parseBind("$PWD/etc/weave_50-weave.network:/etc/systemd/network/50-weave.network"),
 		// cni bins
 		bindrw + path.Join(cniPath+":/opt/cni/bin"),

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -140,7 +140,7 @@ func RunNode(k8srelease, name, kubeSpawnDirParent string) error {
 			bindro + path.Join(k8sOutputDir, "kubectl:/usr/bin/kubectl"),
 			// service files
 			bindro + path.Join(goPath, "/src/k8s.io/kubernetes/build/debs/kubelet.service:/usr/lib/systemd/system/kubelet.service"),
-			bindro + path.Join(goPath, "/src/k8s.io/release/rpm/10-kubeadm.conf:/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"),
+			bindro + path.Join(goPath, "/src/k8s.io/kubernetes/build/rpms/10-kubeadm.conf:/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"),
 			// config
 			bindro + parseBind("$PWD/etc/kube_20-kubeadm-extra-args-k8s18.conf:/etc/systemd/system/kubelet.service.d/20-kubeadm-extra-args.conf"),
 		}

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -57,7 +57,6 @@ func getDefaultBinds(cniPath string) []string {
 		bindro + parseBind("$PWD/etc/daemon.json:/etc/docker/daemon.json"),
 		bindro + parseBind("$PWD/etc/kubeadm.yml:/etc/kubeadm/kubeadm.yml"),
 		bindro + parseBind("$PWD/etc/docker_20-kubeadm-extra-args.conf:/etc/systemd/system/docker.service.d/20-kubeadm-extra-args.conf"),
-		bindro + parseBind("$PWD/etc/kube_20-kubeadm-extra-args.conf:/etc/systemd/system/kubelet.service.d/20-kubeadm-extra-args.conf"),
 		bindro + parseBind("$PWD/etc/kube_tmpfiles_kubelet.conf:/usr/lib/tmpfiles.d/kubelet.conf"),
 		bindro + parseBind("$PWD/etc/weave_50-weave.network:/etc/systemd/network/50-weave.network"),
 		// cni bins
@@ -126,6 +125,8 @@ func RunNode(k8srelease, name, kubeSpawnDirParent string) error {
 			// service files
 			bindro + parseBind("$PWD/k8s/kubelet.service:/usr/lib/systemd/system/kubelet.service"),
 			bindro + parseBind("$PWD/k8s/10-kubeadm.conf:/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"),
+			// config
+			bindro + parseBind("$PWD/etc/kube_20-kubeadm-extra-args.conf:/etc/systemd/system/kubelet.service.d/20-kubeadm-extra-args.conf"),
 		}
 	} else {
 		k8sOutputDir, err := utils.GetK8sBuildOutputDir(filepath.Join(goPath, "/src/k8s.io/kubernetes"))
@@ -140,6 +141,8 @@ func RunNode(k8srelease, name, kubeSpawnDirParent string) error {
 			// service files
 			bindro + path.Join(goPath, "/src/k8s.io/kubernetes/build/debs/kubelet.service:/usr/lib/systemd/system/kubelet.service"),
 			bindro + path.Join(goPath, "/src/k8s.io/release/rpm/10-kubeadm.conf:/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"),
+			// config
+			bindro + parseBind("$PWD/etc/kube_20-kubeadm-extra-args-k8s18.conf:/etc/systemd/system/kubelet.service.d/20-kubeadm-extra-args.conf"),
 		}
 	}
 	args = append(args, k8sbinds...)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -117,3 +117,7 @@ func IsTerminal(fd uintptr) bool {
 	_, _, err := unix.Syscall(unix.SYS_IOCTL, fd, uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&termios)))
 	return err == 0
 }
+
+func IsK8sDev(k8srel string) bool {
+	return k8srel == "" || k8srel == "dev"
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -111,6 +111,20 @@ func GetValidKubeConfig() string {
 	return kcPath
 }
 
+func GetK8sBuildOutputDir(k8sRepoPath string) (string, error) {
+	// first try to use "_output/dockerized/bin/linux/amd64"
+	outputPath := filepath.Join(k8sRepoPath, "_output/dockerized/bin/linux/amd64")
+	if err := CheckValidDir(outputPath); err != nil {
+		// fall back to "_output/bin"
+		outputPath = filepath.Join(k8sRepoPath, "_output/bin")
+		if err := CheckValidDir(outputPath); err != nil {
+			return "", err
+		}
+	}
+
+	return outputPath, nil
+}
+
 // IsTerminal returns true if the given file descriptor is a terminal.
 func IsTerminal(fd uintptr) bool {
 	var termios syscall.Termios

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -19,7 +19,7 @@ KUBEADM_NSPAWN_TMP=/tmp/kube-spawn
 kubeadm reset
 systemctl start kubelet.service
 
-KUBE_HYPERKUBE_IMAGE="10.22.0.1:5000/hyperkube-amd64" kubeadm init --skip-preflight-checks --config /etc/kubeadm/kubeadm.yml --kubernetes-version=latest
+KUBE_HYPERKUBE_IMAGE="10.22.0.1:5000/hyperkube-amd64" kubeadm init --skip-preflight-checks --config /etc/kubeadm/kubeadm.yml
 kubeadm token generate > ${KUBEADM_NSPAWN_TMP}/token
 kubeadm token create $(cat ${KUBEADM_NSPAWN_TMP}/token) --description 'kube-spawn bootstrap token' --ttl 0
 


### PR DESCRIPTION
As the `k8srelease` can be either `"dev"` or `""` in case of development version of K8s, we should check for both `k8srelease != ""` and  `k8srelease != "dev"`. Move the existing helper `isDev()` to `utils.IsK8sDev()` to make it usable from nspawntool too.

Fix URL for gcr.io as the registry `gcr.io` has changed its prefix to `google-containers`.

Reported & debugged by @iaguis
