### PR TITLE
fix go get command for dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: vendor all reset-cni
-.PHONY: clean clean-bins clean-rootfs clean-image clean-ssh-keys 
+.PHONY: clean clean-bins clean-rootfs clean-image clean-ssh-keys
 
 VERSION=$(shell git describe --tags --always --dirty)
 
@@ -14,7 +14,7 @@ all:
 vendor: | dep
 	dep ensure
 dep:
-	@which dep || go get -u github.com/golang/dep
+	@which dep || go get -u github.com/golang/dep/cmd/dep
 
 clean: clean-bins clean-rootfs clean-image clean-ssh-keys
 clean-ssh-keys:


### PR DESCRIPTION
On vagrant I'm getting:
```
[vagrant@fedora26-vbox ~]$ ./build.sh 
+ cd /home/vagrant/go/src/github.com/kinvolk/kube-spawn
+ go get -u github.com/containernetworking/plugins/plugins/...
+ make vendor all
which: no dep in (/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/vagrant/.local/bin:/home/vagrant/bin:/home/vagrant/go/bin:/usr/local/go/bin)
dep ensure
make: dep: Command not found
make: *** [Makefile:15: vendor] Error 127
```
The `dep` binary is not installed, changing the go get path to `github.com/golang/dep/cmd/dep` fixes it.

Cheers,