### PR TITLE
Update Gopkg.lock and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # Folders
 _obj
 _test
+.kube-spawn
+.vagrant
+k8s
 
 # Architecture specific extensions/prefixes
 *.[568vq]
@@ -24,6 +27,7 @@ _testmain.go
 *.prof
 
 *.lck
+*.log
 
 # vendor
 /vendor
@@ -31,11 +35,12 @@ _testmain.go
 # binaries
 /cni-noop
 /cnispawn
-/kubeadm-systemd
+/kube-spawn
+/kube-spawn-runc
 
 # ssh keys
 /id_rsa*
 
 # containers
-/kubeadm-systemd-*
+/kube-spawn-*
 /rootfs.tar.xz

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -119,6 +119,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b41c6f0173db18c16f5fc85d794531c79ec8208f452403c0927de612bc5e24e3"
+  inputs-digest = "c091c53106daeb66f7bd43b86f2881bb4f9d47292ddde34747a53713938cd90d"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
Update `Gopkg.lock` to sync with `Gopkg.toml`, by running `dep ensure` to regenerate inputs-digest to avoid warnings like:

```
$ dep status
Lock inputs-digest mismatch. This happens when Gopkg.toml is modified.
Run `dep ensure` to regenerate the inputs-digest.
```

Also update `.gitignore` to include more unnecessary files.