### PR TITLE
pkg/bootstrap: move k8s download directory to .kube-spawn/k8s

### DIFF
--- a/cmd/kube-spawn/setup.go
+++ b/cmd/kube-spawn/setup.go
@@ -102,7 +102,7 @@ func doSetup(numNodes int, baseImage, kubeSpawnDir string) {
 	doCheckK8sStableRelease(k8srelease)
 
 	if !utils.IsK8sDev(k8srelease) {
-		if err := bootstrap.DownloadK8sBins(k8srelease, "./k8s"); err != nil {
+		if err := bootstrap.DownloadK8sBins(k8srelease, bootstrap.K8sDownloadDir); err != nil {
 			log.Fatalf("Error downloading k8s files: %s", err)
 		}
 	}

--- a/pkg/bootstrap/kubernetes.go
+++ b/pkg/bootstrap/kubernetes.go
@@ -25,6 +25,7 @@ var (
 		k8sGithubURL + "kubelet.service",
 		k8sGithubURL + "10-kubeadm.conf",
 	}
+	K8sDownloadDir string = ".kube-spawn/k8s"
 )
 
 func Download(url, fpath string) (*os.File, error) {

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -165,28 +165,28 @@ func getK8sBindOpts(k8srelease, goPath string) ([]bindOption, error) {
 			// bins
 			{
 				bindro,
-				parseBind("$PWD/k8s/kubelet"),
+				filepath.Join(parseBind("$PWD"), bootstrap.K8sDownloadDir, "kubelet"),
 				"/usr/bin/kubelet",
 			},
 			{
 				bindro,
-				parseBind("$PWD/k8s/kubeadm"),
+				filepath.Join(parseBind("$PWD"), bootstrap.K8sDownloadDir, "kubeadm"),
 				"/usr/bin/kubeadm",
 			},
 			{
 				bindro,
-				parseBind("$PWD/k8s/kubectl"),
+				filepath.Join(parseBind("$PWD"), bootstrap.K8sDownloadDir, "kubectl"),
 				"/usr/bin/kubectl",
 			},
 			// service files
 			{
 				bindro,
-				parseBind("$PWD/k8s/kubelet.service"),
+				filepath.Join(parseBind("$PWD"), bootstrap.K8sDownloadDir, "kubelet.service"),
 				"/usr/lib/systemd/system/kubelet.service",
 			},
 			{
 				bindro,
-				parseBind("$PWD/k8s/10-kubeadm.conf"),
+				filepath.Join(parseBind("$PWD"), bootstrap.K8sDownloadDir, "10-kubeadm.conf"),
 				"/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
 			},
 			// config


### PR DESCRIPTION
We should place the temporary download directory `k8s` under `.kube-spawn`, to be consistent with other user files.