### PR TITLE
pkg/bootstrap: check also for ecryptfs under overlayfs

### DIFF
--- a/pkg/bootstrap/util.go
+++ b/pkg/bootstrap/util.go
@@ -26,9 +26,11 @@ import (
 )
 
 const (
-	tmpDir      string = ".kube-spawn/default"
-	FsMagicAUFS        = 0x61756673 // https://goo.gl/CBwx43
-	FsMagicZFS         = 0x2FC12FC1 // https://goo.gl/xTvzO5
+	tmpDir string = ".kube-spawn/default"
+
+	FsMagicAUFS     = 0x61756673 // https://goo.gl/CBwx43
+	FsMagicECRYPTFS = 0xF15F     // https://goo.gl/4akUXJ
+	FsMagicZFS      = 0x2FC12FC1 // https://goo.gl/xTvzO5
 )
 
 func CreateSharedTmpdir() {
@@ -58,6 +60,8 @@ func PathSupportsOverlay(path string) error {
 	switch data.Type {
 	case FsMagicAUFS:
 		return fmt.Errorf("unsupported filesystem: aufs")
+	case FsMagicECRYPTFS:
+		return fmt.Errorf("unsupported filesystem: ecryptfs")
 	case FsMagicZFS:
 		return fmt.Errorf("unsupported filesystem: zfs")
 	}


### PR DESCRIPTION
As moby does not allow ecryptfs to be used as underlying filesystem of overlayfs, we should also check for ecryptfs in `PathSupportsOverlay()` to prevent ecryptfs from being used.

Fixes https://github.com/kinvolk/kube-spawn/issues/126