### PR TITLE
[WIP] Check signature of CoreOS image

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,13 +10,14 @@
 [[projects]]
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
-  revision = "f533f7a102197536779ea3a8cb881d639e21ec5a"
-  version = "v0.4.2"
+  revision = "78439966b38d69bf38227fbf57ac8a6fee70f69a"
+  version = "v0.4.5"
 
 [[projects]]
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
-  revision = "3d4380f53a34dcdc95f0c1db702615992b38d9a4"
+  revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
+  version = "v1.0.3"
 
 [[projects]]
   name = "github.com/containernetworking/cni"
@@ -27,66 +28,62 @@
 [[projects]]
   name = "github.com/containernetworking/plugins"
   packages = ["pkg/ns"]
-  revision = "5bbff37294de9dfb33771dac6f53411c88abe62a"
+  revision = "a714098daf75b8ed7dbbaa054f6ae7c13b9727f3"
   version = "v0.6.0-rc1"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/coreos/ioprogress"
+  packages = ["."]
+  revision = "4637e494fd9b23c5565ee193e89f91fdc1639bc0"
+
+[[projects]]
   name = "github.com/docker/distribution"
-  packages = ["digestset","reference"]
-  revision = "f86db6b22663a27ba4d278220b7e34be528b1e79"
+  packages = ["digest","reference"]
+  revision = "48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89"
+  version = "v2.6.2"
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = ["api","api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/image","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/time","api/types/versions","api/types/volume","client","pkg/ioutils","pkg/longpath","pkg/mount","pkg/system","pkg/tlsconfig"]
-  revision = "3d6ab220db348d82310487e3156d445f19dc0661"
+  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/mount","api/types/network","api/types/reference","api/types/registry","api/types/strslice","api/types/swarm","api/types/time","api/types/versions","api/types/volume","client","pkg/tlsconfig"]
+  revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
   version = "v1.13.1"
 
 [[projects]]
   name = "github.com/docker/go-connections"
   packages = ["nat","sockets","tlsconfig"]
-  revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
+  revision = "990a1a1a70b0da4c4cb70e117971a4f0babfbf1a"
   version = "v0.2.1"
 
 [[projects]]
-  branch = "master"
   name = "github.com/docker/go-units"
   packages = ["."]
-  revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
+  revision = "f2d77a61e3c169b43402a0a1e84f06daf29b8190"
+  version = "v0.3.1"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/docker/libtrust"
-  packages = ["."]
-  revision = "aabc10ec26b754e797f9028f4589c5b7bd90dc20"
-
-[[projects]]
-  branch = "master"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/opencontainers/go-digest"
-  packages = ["."]
-  revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
+  name = "github.com/opencontainers/runc"
+  packages = ["libcontainer/user"]
+  revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
+  version = "v0.1.1"
 
 [[projects]]
-  name = "github.com/opencontainers/image-spec"
-  packages = ["specs-go","specs-go/v1"]
-  revision = "1b24aca6c83b826936087d56271f34fcef46c7b2"
-
-[[projects]]
-  branch = "master"
   name = "github.com/pkg/errors"
   packages = ["."]
-  revision = "c605e284fe17294bda444b34710735b29d1a9d90"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "4d647c8944eb42504a714e57e97f244ed6344722"
+  revision = "2df9a531813370438a4d79bfc33e21f58063ed87"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -98,27 +95,35 @@
   branch = "master"
   name = "github.com/vishvananda/netlink"
   packages = [".","nl"]
-  revision = "4e28683688429fdf8413cc610d59fb1841986300"
+  revision = "f5a6f697a596c788d474984a38a0ac4ba0719e93"
 
 [[projects]]
   branch = "master"
   name = "github.com/vishvananda/netns"
   packages = ["."]
-  revision = "8ba1072b58e0c2a240eb5f6120165c7776c3e7b8"
+  revision = "86bef332bfc3b59b7624a600bd53009ce91a9829"
 
 [[projects]]
+  branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  revision = "eb71ad9bd329b5ac0fd0148dd99bd62e8be8e035"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp","proxy"]
-  revision = "8663ed5da4fd087c3cfb99a996e628b72e2f0948"
+  revision = "1c05540f6879653db88113bc4a2b70aec4bd491f"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "076b546753157f758b316e59bcb51e6807c04057"
+  revision = "07c182904dbd53199946ba614a412c61d3c548f5"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c091c53106daeb66f7bd43b86f2881bb4f9d47292ddde34747a53713938cd90d"
+  inputs-digest = "dedcd3125e9fd05a923eb1bcc1a627379e8467f8d2830c46410336f79d1c2533"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/kube-spawn/up.go
+++ b/cmd/kube-spawn/up.go
@@ -17,12 +17,26 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
+	"os/exec"
 
+	"github.com/coreos/ioprogress"
 	"github.com/spf13/cobra"
 
 	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
+	"golang.org/x/crypto/openpgp/packet"
+)
+
+const (
+	imageUrl     = "https://alpha.release.core-os.net/amd64-usr/current/coreos_developer_container.bin.bz2"
+	signatureUrl = "https://alpha.release.core-os.net/amd64-usr/current/coreos_developer_container.bin.bz2.sig"
 )
 
 var (
@@ -52,6 +66,11 @@ func runUp(cmd *cobra.Command, args []string) {
 	}
 
 	bootstrap.PrepareCoreosImage()
+	if err := showImage(); err != nil {
+		if err := importRawImage(); err != nil {
+			log.Fatalf("%v\n", err)
+		}
+	}
 
 	// e.g: sudo ./kube-spawn setup --nodes=2 --image=coreos
 	doSetup(upNumNodes, upBaseImage, upKubeSpawnDir)
@@ -60,4 +79,277 @@ func runUp(cmd *cobra.Command, args []string) {
 	doInit()
 
 	log.Printf("All nodes are started.")
+}
+
+func downloadFile(dest, url string) error {
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	response, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	progress := &ioprogress.Reader{
+		Reader: response.Body,
+		Size:   response.ContentLength,
+	}
+
+	if _, err := io.Copy(f, progress); err != nil {
+		return err
+	}
+
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func downloadImage() error {
+	return downloadFile("/tmp/coreos_developer_container.bin.bz2", imageUrl)
+}
+
+func downloadSignature() error {
+	return downloadFile("/tmp/coreos_developer_container.bin.bz2.sig", signatureUrl)
+}
+
+func verifyImage() error {
+	// TODO(nhlfr): Try to use or implement some library for managing PGP keys instead
+	// of executing gpg binary.
+	gpgCmdPath, err := exec.LookPath("gpg")
+	if err != nil {
+		gpgCmdPath = "/usr/bin/gpg"
+	}
+
+	importPubKeyArgs := []string{
+		gpgCmdPath,
+		"--keyserver",
+		"keyserver.ubuntu.com",
+		"--recv-key",
+		"50E0885593D2DCB4",
+	}
+
+	importPubKeyCmd := exec.Cmd{
+		Path:   gpgCmdPath,
+		Args:   importPubKeyArgs,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	log.Printf("kopytko")
+
+	if err := importPubKeyCmd.Run(); err != nil {
+		return err
+	}
+
+	exportPubKeyArgs := []string{
+		gpgCmdPath,
+		"--export",
+		"50E0885593D2DCB4",
+		"--export-options",
+		"export-minimal,no-export-attributes",
+	}
+
+	exportPubKeyCmd := exec.Cmd{
+		Path:   gpgCmdPath,
+		Args:   exportPubKeyArgs,
+		Env:    os.Environ(),
+		Stderr: os.Stderr,
+	}
+
+	exportStdout, err := exportPubKeyCmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("error creating stdout pipe: %s", err)
+	}
+	defer exportStdout.Close()
+
+	if err := exportPubKeyCmd.Start(); err != nil {
+		return fmt.Errorf("error running gpg: %s", err)
+	}
+
+	pubKeyArmor, err := ioutil.ReadAll(exportStdout)
+	if err != nil {
+		return fmt.Errorf("error reading public key from stdout: %s", err)
+	}
+
+	if err := exportPubKeyCmd.Wait(); err != nil {
+		return fmt.Errorf("error running gpg: %s", err)
+	}
+
+	hexdumpCmdPath, err := exec.LookPath("hexdump")
+	if err != nil {
+		hexdumpCmdPath = "/usr/bin/hexdump"
+	}
+
+	hexdumpArgs := []string{
+		hexdumpCmdPath,
+		"/dev/stdin",
+		"-v",
+		"-e",
+		"/1 \"%02X\"",
+	}
+
+	hexdumpCmd := exec.Cmd{
+		Path:   hexdumpCmdPath,
+		Args:   hexdumpArgs,
+		Env:    os.Environ(),
+		Stderr: os.Stderr,
+	}
+
+	hexdumpStdin, err := hexdumpCmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("error creating stdin pipe: %s", err)
+	}
+	// defer hexdumpStdin.Close()
+
+	hexdumpStdout, err := hexdumpCmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("error creating stdout pipe: %s", err)
+	}
+	defer hexdumpStdout.Close()
+
+	if _, err := hexdumpStdin.Write(pubKeyArmor); err != nil {
+		return fmt.Errorf("error writing public key to stdin: %s", err)
+	}
+
+	if err := hexdumpCmd.Start(); err != nil {
+		return fmt.Errorf("error running hexdump: %s", err)
+	}
+
+	hexdumpStdin.Close()
+
+	pubKeyHex, err := ioutil.ReadAll(hexdumpStdout)
+	if err != nil {
+		return fmt.Errorf("error reading public key hex from stdout: %s", err)
+	}
+
+	if err := hexdumpCmd.Wait(); err != nil {
+		return fmt.Errorf("error running hexdump: %s", err)
+	}
+
+	imageContent, err := ioutil.ReadFile("/tmp/coreos_developer_container.bin.bz2")
+	if err != nil {
+		return err
+	}
+
+	signatureFile, err := os.Open("/tmp/coreos_developer_container.bin.bz2.sig")
+	if err != nil {
+		return err
+	}
+	defer signatureFile.Close()
+
+	signatureContent, err := packet.Read(signatureFile)
+	if err != nil {
+		return err
+	}
+
+	signature, ok := signatureContent.(*packet.Signature)
+	if !ok {
+		return fmt.Errorf("invalid signature file")
+	}
+
+	hash := signature.Hash.New()
+
+	pubKeyBin, err := hex.DecodeString(string(pubKeyHex[:]))
+	if err != nil {
+		return err
+	}
+
+	pubKeyContent, err := packet.Read(bytes.NewReader(pubKeyBin))
+	if err != nil {
+		return err
+	}
+
+	pubKey, ok := pubKeyContent.(*packet.PublicKey)
+	if !ok {
+		return fmt.Errorf("invalid public key")
+	}
+
+	if _, err := hash.Write(imageContent); err != nil {
+		return err
+	}
+
+	if err := pubKey.VerifySignature(hash, signature); err != nil {
+		return fmt.Errorf("signature verification failed: %s", err)
+	}
+
+	return nil
+}
+
+func importRawImage() error {
+	var cmdPath string
+	var err error
+
+	if err := downloadImage(); err != nil {
+		return err
+	}
+	if err := downloadSignature(); err != nil {
+		return err
+	}
+	if err := verifyImage(); err != nil {
+		return err
+	}
+	log.Printf("Image downloaded and verified successfully")
+
+	if cmdPath, err = exec.LookPath("machinectl"); err != nil {
+		// fall back to an ordinary abspath to machinectl
+		cmdPath = "/usr/bin/machinectl"
+	}
+
+	args := []string{
+		cmdPath,
+		"pull-raw",
+		"https://alpha.release.core-os.net/amd64-usr/current/coreos_developer_container.bin.bz2",
+		"coreos",
+	}
+
+	cmd := exec.Cmd{
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running machinectl pull-raw: %s", err)
+	}
+
+	return nil
+}
+
+func showImage() error {
+	var cmdPath string
+	var err error
+
+	if cmdPath, err = exec.LookPath("machinectl"); err != nil {
+		// fall back to an ordinary abspath to machinectl
+		cmdPath = "/usr/bin/machinectl"
+	}
+
+	args := []string{
+		cmdPath,
+		"show-image",
+		"coreos",
+	}
+
+	cmd := exec.Cmd{
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running machinectl show-image: %s", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
systemd-nspawn/machinectl doesn't have a functionality of checking downloaded images by GPG signatures. We need to download the image and validate it by ourselves and then import it by machinectl.