### PR TITLE
vagrant: Add vagrant-libvirt support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,11 +5,15 @@ ENV["TERM"] = "xterm-256color"
 ENV["LC_ALL"] = "en_US.UTF-8"
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "jhcook/fedora26" # defaults to fedora
+  config.vm.box = "fedora/26-cloud-base" # defaults to fedora
 
   # common parts
   if Vagrant.has_plugin?("vagrant-vbguest")
     config.vbguest.auto_update = false
+  end
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.cpus = 2
+    libvirt.memory = 4096
   end
   config.vm.provider :virtualbox do |vb|
     vb.check_guest_additions = false
@@ -40,26 +44,26 @@ Vagrant.configure("2") do |config|
 
   # Ubuntu 17.04 (Zesty)
   config.vm.define "ubuntu", autostart: false do |ubuntu|
-    config.vm.box = "ubuntu/zesty64"
+    config.vm.box = "generic/ubuntu1704"
     config.vm.provision "shell", inline: "curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -; echo \"deb http://apt.kubernetes.io/ kubernetes-xenial main\" > /etc/apt/sources.list.d/kubernetes.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io golang git qemu-utils selinux-utils systemd-container kubectl tmux"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
-    config.vm.synced_folder ".", "/home/ubuntu/go/src/github.com/kinvolk/kube-spawn",
+    config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
       create: true,
-      owner: "ubuntu",
-      group: "ubuntu",
+      owner: "vagrant",
+      group: "vagrant",
       type: "rsync",
       rsync__exclude: ".kube-spawn/"
 
-    config.vm.provision "shell", inline: "mkdir -p /home/ubuntu/go ; chown -R ubuntu:ubuntu /home/ubuntu/go"
-    config.vm.provision "shell", env: {"GOPATH" => "/home/ubuntu/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
-    config.vm.provision "shell", env: {"VUSER" => "ubuntu"}, path: "scripts/vagrant-mod-env.sh"
+    config.vm.provision "shell", inline: "mkdir -p /home/vagrant/go ; chown -R vagrant:vagrant /home/vagrant/go"
+    config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
+    config.vm.provision "shell", env: {"VUSER" => "vagrant"}, path: "scripts/vagrant-mod-env.sh"
   end
 
   # Debian testing
   config.vm.define "debian", autostart: false do |debian|
     config.vm.box = "debian/testing64"
-    config.vm.provision "shell", inline: "echo deb http://apt.dockerproject.org/repo debian-stretch main > /etc/apt/sources.list.d/docker.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated docker-engine; DEBIAN_FRONTEND=noninteractive apt-get install -y golang git kubernetes-client qemu-utils selinux-utils systemd-container tmux"
+    config.vm.provision "shell", inline: "echo deb http://httpredir.debian.org/debian unstable main >> /etc/apt/sources.list; echo deb http://apt.dockerproject.org/repo debian-stretch main > /etc/apt/sources.list.d/docker.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated docker-engine; DEBIAN_FRONTEND=noninteractive apt-get install -y golang git qemu-utils selinux-utils systemd-container tmux; DEBIAN_FRONTEND=noninteractive apt-get install -y -t unstable kubernetes-client"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",


### PR DESCRIPTION
vagrant-libvirt plugin allows to run vagrant VMs by libvirt, using KVM as a hypervisor. That change also required to use Fedora box compatible both with virtualbox and libvirt providers.