### PR TITLE
kube-spawn machine naming: use kubespawn%d without dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ $ sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=dev
 All nodes can be seen with `machinectl list`, `machinectl shell` can be used to access a node, for example:
 
 ```
-sudo machinectl shell root@kube-spawn-0
+sudo machinectl shell root@kubespawn0
 ```
 
 The password is `k8s`.

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -25,7 +25,7 @@ However, it is also true that disabling security framework is not always desirab
 If your `start` (or `setup`) command fails upon restarting machines without any reason, please try to removing existing images like:
 
 ```
-$ for i in $(seq 0 2); do sudo machinectl remove kube-spawn-$i; done
+$ for i in $(seq 0 2); do sudo machinectl remove kubespawn$i; done
 ```
 
 That could make the setup process do the job again. Ideally the remaining images should be handled automatically. For that it is planned to implement storing node infos persistently. (See https://github.com/kinvolk/kube-spawn/issues/37)

--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	containerNameTemplate string = "kube-spawn-%d"
+	containerNameTemplate string = "kubespawn%d"
 	ctHashsizeModparam    string = "/sys/module/nf_conntrack/parameters/hashsize"
 	ctHashsizeValue       string = "131072"
 	ctMaxSysctl           string = "/proc/sys/net/nf_conntrack_max"
@@ -107,14 +107,14 @@ func GetRunningNodes() ([]Node, error) {
 		}
 
 		// an example line from systemd v232 or newer:
-		//  kube-spawn-0 container systemd-nspawn coreos 1478.0.0 10.22.0.130...
+		//  kubespawn0 container systemd-nspawn coreos 1478.0.0 10.22.0.130...
 		//
 		// systemd v231 or older:
-		//  kube-spawn-0 container systemd-nspawn
+		//  kubespawn0 container systemd-nspawn
 
 		var ipaddr string
 		machineName := strings.TrimSpace(line[0])
-		if !strings.HasPrefix(machineName, "kube-spawn-") {
+		if !strings.HasPrefix(machineName, "kubespawn") {
 			continue
 		}
 
@@ -137,7 +137,7 @@ func GetRunningNodes() ([]Node, error) {
 }
 
 func GetIPAddressLegacy(mach string) (string, error) {
-	// machinectl status kube-spawn-0 --no-pager | grep Address
+	// machinectl status kubespawn0 --no-pager | grep Address
 	args := []string{
 		"status",
 		mach,


### PR DESCRIPTION
The name of the machine given to machinectl (e.g. kube-spawn-0) is also
used to set the cgroup path. Example:
/machine.slice/machine-kube\x2dspawn\x2d0.scope

Having dashes make things more complicated because they are escaped by
systemd to '\x2d' in the cgroup path.

When adding the support for cgroup-per-qos in kube-spawn, we will need
to pass the parameter --cgroup-root= to the Kubelet. With the '\x2d'
escape sequence, we have now a backslash. That would need to be escaped
when writing the kubelet service file.

So instead of over-complicating things with a double-escaping sequence,
let's just get rid of the dashes.

-----

Related topics:
- https://github.com/kinvolk/kube-spawn/issues/12#issuecomment-331495622
- https://github.com/kubernetes-incubator/rktlet/pull/124