### PR TITLE
Fix k8sGithubURL and kubeadm config file name

### DIFF
--- a/pkg/bootstrap/kubernetes.go
+++ b/pkg/bootstrap/kubernetes.go
@@ -13,8 +13,8 @@ import (
 
 const (
 	k8sURL         string = "https://dl.k8s.io/v$VERSION/bin/linux/amd64/"
-	k8sGithubURL   string = "https://raw.githubusercontent.com/kubernetes/release/master/rpm/"
-	staticSocatUrl string = "https://raw.githubusercontent.com/andrew-d/static-binaries/master/binaries/linux/x86_64/socat"
+	k8sGithubURL   string = "https://raw.githubusercontent.com/kubernetes/release/706c64874faa5653cf963fb30de390969e25f175/rpm/"
+	staticSocatUrl string = "https://raw.githubusercontent.com/andrew-d/static-binaries/530df977dd38ba3b4197878b34466d49fce69d8e/binaries/linux/x86_64/socat"
 )
 
 var (
@@ -23,7 +23,7 @@ var (
 		k8sURL + "kubeadm",
 		k8sURL + "kubectl",
 		k8sGithubURL + "kubelet.service",
-		k8sGithubURL + "10-kubeadm.conf",
+		k8sGithubURL + "10-kubeadm-pre-1.8.conf",
 	}
 )
 

--- a/pkg/nspawntool/binds.go
+++ b/pkg/nspawntool/binds.go
@@ -146,8 +146,8 @@ func getK8sBindOpts(k8srelease, kubeSpawnDir, goPath string) ([]bindOption, erro
 			},
 			{
 				bindro,
-				path.Join(goPath, "/src/k8s.io/kubernetes/build/rpms/10-kubeadm.conf"),
-				"/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
+				path.Join(goPath, "/src/k8s.io/kubernetes/build/rpms/10-kubeadm-pre-1.8.conf"),
+				"/etc/systemd/system/kubelet.service.d/10-kubeadm-pre-1.8.conf",
 			},
 		}, nil
 	} else {
@@ -177,8 +177,8 @@ func getK8sBindOpts(k8srelease, kubeSpawnDir, goPath string) ([]bindOption, erro
 			},
 			{
 				bindro,
-				path.Join(kubeSpawnDir, "/k8s/10-kubeadm.conf"),
-				"/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
+				path.Join(kubeSpawnDir, "/k8s/10-kubeadm-pre-1.8.conf"),
+				"/etc/systemd/system/kubelet.service.d/10-kubeadm-pre-1.8.conf",
 			},
 		}, nil
 	}


### PR DESCRIPTION
Its name was changed recently. Switch to a commit to avoid this kind of
issues in the future. Same for the socat repo.