### PR TITLE
Specify `dep ensure` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ go get -d github.com/kinvolk/kube-spawn
 ```
 # Build the tool
 $ cd $GOPATH/src/github.com/kinvolk/kube-spawn
+$ dep ensure -v
 $ make vendor all
 
 $ sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn up --image=coreos --nodes=3


### PR DESCRIPTION
Without `dep ensure`, the build fails so we should specify that in the
README.

This is in conflict with https://github.com/kinvolk/kube-spawn/pull/155/ . i-e if we don't end up merging that work, then I think we should have this in the docs.