### PR TITLE
nspawntool: use stage1 filename

### DIFF
--- a/pkg/nspawntool/binds.go
+++ b/pkg/nspawntool/binds.go
@@ -195,7 +195,7 @@ func getRktBindOpts(kubeSpawnDir, rktBin, rktStage1Image, rktletBin string) []bi
 		{
 			bindro,
 			rktStage1Image,
-			"/usr/bin/stage1-coreos.aci",
+			filepath.Join("/usr/bin", filepath.Base(rktStage1Image)),
 		},
 		{
 			bindro,


### PR DESCRIPTION
Instead of hardcoding "stage1-coreos.aci".