### PR TITLE
bootstrap: check for versions of pre-existing binaries

### DIFF
--- a/cmd/kube-spawn/setup.go
+++ b/cmd/kube-spawn/setup.go
@@ -106,7 +106,12 @@ func doSetup(numNodes int, baseImage, kubeSpawnDir string) {
 	doCheckK8sStableRelease(k8srelease)
 
 	if !utils.IsK8sDev(k8srelease) {
-		if err := bootstrap.DownloadK8sBins(k8srelease, path.Join(kubeSpawnDir, "k8s")); err != nil {
+		k8sDir := path.Join(kubeSpawnDir, "k8s")
+		if err := bootstrap.CheckForK8sBinVersions(k8srelease, k8sDir); err != nil {
+			log.Fatalf("Version mismatch with existing binaries. Please clean up %s: %v", k8sDir, err)
+		}
+
+		if err := bootstrap.DownloadK8sBins(k8srelease, k8sDir); err != nil {
 			log.Fatalf("Error downloading k8s files: %s", err)
 		}
 	}

--- a/pkg/utils/semver.go
+++ b/pkg/utils/semver.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver"
+)
+
+// IsSemVerOrNewer returns true if a semantic version string keyVersion is newer
+// than or same as conVersion. For example, if keyVersion is 1.8.1 and
+// conVersion is 1.7.7, it returns true.
+func IsSemVerOrNewer(keyVersion, conVersion string) bool {
+	v, err := semver.NewVersion(keyVersion)
+	if err != nil {
+		return false
+	}
+
+	c, err := semver.NewConstraint(fmt.Sprintf(">=%s", conVersion))
+	if err != nil {
+		return false
+	}
+
+	return c.Check(v)
+}
+
+// IsSemVer returns true if a semantic version string keyVersion is the same as
+// conVersion. For example, if both keyVersion and conVersion are 1.8.1,
+// it returns true.
+func IsSemVer(keyVersion, conVersion string) bool {
+	v, err := semver.NewVersion(keyVersion)
+	if err != nil {
+		return false
+	}
+
+	c, err := semver.NewConstraint(fmt.Sprintf("=%s", conVersion))
+	if err != nil {
+		return false
+	}
+
+	return c.Check(v)
+}

--- a/pkg/utils/semver_test.go
+++ b/pkg/utils/semver_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestIsSemVerOrNewer(t *testing.T) {
+	testCases := []struct {
+		keyVersion     string
+		conVersion     string
+		expectedResult bool
+	}{
+		{
+			keyVersion:     "1.8.0",
+			conVersion:     "1.8.0",
+			expectedResult: true,
+		},
+		{
+			keyVersion:     "1.8.1",
+			conVersion:     "1.8.0",
+			expectedResult: true,
+		},
+		{
+			keyVersion:     "1.8.0",
+			conVersion:     "1.8.1",
+			expectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		outResult := IsSemVerOrNewer(tc.keyVersion, tc.conVersion)
+		if tc.expectedResult != outResult {
+			t.Fatalf("Failure at test case %d: expected %v, got %v\n", i, tc.expectedResult, outResult)
+		}
+	}
+}
+
+func TestIsSemVer(t *testing.T) {
+	testCases := []struct {
+		keyVersion     string
+		conVersion     string
+		expectedResult bool
+	}{
+		{
+			keyVersion:     "1.8.0",
+			conVersion:     "1.8.0",
+			expectedResult: true,
+		},
+		{
+			keyVersion:     "1.8.1",
+			conVersion:     "1.8.0",
+			expectedResult: false,
+		},
+		{
+			keyVersion:     "1.7.7",
+			conVersion:     "2.0.9",
+			expectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		outResult := IsSemVer(tc.keyVersion, tc.conVersion)
+		if tc.expectedResult != outResult {
+			t.Fatalf("Failure at test case %d: expected %v, got %v\n", i, tc.expectedResult, outResult)
+		}
+	}
+}


### PR DESCRIPTION
We need to check for versions of pre-existing binaries `/var/lib/kube-spawn/k8s/kube{ctl,let,adm}` to be able to avoid version mismatches between different k8s versions.

Versions are obtained by running commands like below:                                          

```                                                                                            
$ kubectl version --client=true --short=true                                                   
$ kubelet --version                                                                            
$ kubeadm version --output=short                                                               
```                                                                                            

Also add helpers checking for semantic versions like `IsSemVer()` or `IsSemVerOrNewer()`, and do some refactoring.

Fixes https://github.com/kinvolk/kube-spawn/issues/154