### PR TITLE
cmd/kube-spawn: ignore resizing storage pool if the pool image does not exist

### DIFF
--- a/cmd/kube-spawn/start.go
+++ b/cmd/kube-spawn/start.go
@@ -149,6 +149,11 @@ func resizeMachineDir(baseImage string, nodesN int) {
 	// estimate get pool size based on sum of virtual image sizes.
 	var poolSize int64
 	var err error
+
+	if !bootstrap.PoolImageExists() {
+		return
+	}
+
 	if poolSize, err = bootstrap.GetPoolSize(baseImage, nodesN); err != nil {
 		// fail hard in case of error, to avoid running unnecessary nodes
 		log.Fatalf("cannot get pool size: %v", err)

--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/kinvolk/kube-spawn/pkg/config"
 	"github.com/kinvolk/kube-spawn/pkg/machinetool"
+	"github.com/kinvolk/kube-spawn/pkg/utils/fs"
 	"github.com/pkg/errors"
 )
 
@@ -174,6 +175,10 @@ func IsNodeRunning(nodeName string) bool {
 		}
 	}
 	return false
+}
+
+func PoolImageExists() bool {
+	return fs.Exists(machinesImage)
 }
 
 func GetPoolSize(baseImage string, nodes int) (int64, error) {


### PR DESCRIPTION
We should not resize the storage pool, if the pool image `/var/lib/machines.raw` does not exist. In that case, it's just fine to ignore resizing the image, because it means that systemd-machined did not have to create an image to be loopback mounted.

Fixes https://github.com/kinvolk/kube-spawn/issues/170