### PR TITLE
Optimize Vagrantfile, support Ubuntu 17.10

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
 
   # Fedora 26
   config.vm.define "fedora", primary: true do |fedora|
-    config.vm.provision "shell", inline: "dnf install -y btrfs-progs docker git go kubernetes qemu-img strace tmux"
+    config.vm.provision "shell", inline: "dnf install -y btrfs-progs git go iptables libselinux-utils polkit qemu-img systemd-container"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
@@ -42,10 +42,10 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", env: {"VUSER" => "vagrant"}, path: "scripts/vagrant-mod-env.sh"
   end
 
-  # Ubuntu 17.04 (Zesty)
+  # Ubuntu 17.10 (Artful)
   config.vm.define "ubuntu", autostart: false do |ubuntu|
-    config.vm.box = "generic/ubuntu1704"
-    config.vm.provision "shell", inline: "curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -; echo \"deb http://apt.kubernetes.io/ kubernetes-xenial main\" > /etc/apt/sources.list.d/kubernetes.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io golang git qemu-utils selinux-utils systemd-container kubectl tmux"
+    config.vm.box = "generic/ubuntu1710"
+    config.vm.provision "shell", inline: "apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y btrfs-progs git golang iptables policykit-1 qemu-utils selinux-utils systemd-container"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
@@ -63,7 +63,7 @@ Vagrant.configure("2") do |config|
   # Debian testing
   config.vm.define "debian", autostart: false do |debian|
     config.vm.box = "debian/testing64"
-    config.vm.provision "shell", inline: "echo deb http://httpredir.debian.org/debian unstable main >> /etc/apt/sources.list; echo deb http://apt.dockerproject.org/repo debian-stretch main > /etc/apt/sources.list.d/docker.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated docker-engine; DEBIAN_FRONTEND=noninteractive apt-get install -y golang git qemu-utils selinux-utils systemd-container tmux; DEBIAN_FRONTEND=noninteractive apt-get install -y -t unstable kubernetes-client"
+    config.vm.provision "shell", inline: "echo deb http://httpredir.debian.org/debian unstable main >> /etc/apt/sources.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y btrfs-progs git golang iptables policykit-1 qemu-utils selinux-utils systemd-container"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",

--- a/doc/distro.md
+++ b/doc/distro.md
@@ -1,0 +1,55 @@
+## How to set up kube-spawn on various Linux distros
+
+### Common
+
+First of all, to be able to run kube-spawn, you need to make sure that the
+following things are done on your system, no matter which distro you run on.
+
+* make sure that systemd v233 or newer is installed
+* set SELinux mode to either `Permissive` or `Disabled`, e.g.: `sudo setenforce 0`
+* set env variables correctly
+  * set `GOPATH` correctly, e.g. `export GOPATH=$HOME/go`
+  * set `KUBECONFIG`: `export KUBECONFIG=/var/lib/kube-spawn/default/kubeconfig`
+
+### Fedora
+
+Fedora 26 or newer is needed, mainly for systemd.
+kube-spawn works fine on Fedora as long as the following dependencies are installed.
+
+#### install required packages
+
+```
+sudo dnf install -y btrfs-progs git go iptables libselinux-utils polkit qemu-img systemd-container
+```
+
+### Ubuntu
+
+Ubuntu 17.10 (Artful) or newer is needed, mainly for systemd.
+
+#### install required packages
+
+```
+sudo apt-get install -y btrfs-progs git golang iptables policykit-1 qemu-utils selinux-utils systemd-container
+```
+
+#### systemd-resolved
+
+On Ubuntu 17.10, systemd-resolved is enabled by default, as well as its stub
+listener, which listens on 127.0.0.53:53 for the local DNS resolution.
+Unfortunately, systemd v234, the default version on Ubuntu 17.10, has bugs
+regarding DNS resolution. Thus we need to disable systemd-resolved on the host,
+which will make systemd-resolved disabled inside nspawn containers as well.
+So it's recommended to run the following commands on the host, before starting
+kube-spawn clusters.
+
+```
+sudo sed -i -e 's/^#*.*DNSStubListener=.*$/DNSStubListener=no/' /etc/systemd/resolved.conf
+sudo sed -i -e 's/nameserver 127.0.0.53/nameserver 8.8.8.8/' /etc/resolv.conf
+systemctl is-active systemd-resolved >& /dev/null && sudo systemctl stop systemd-resolved
+systemctl is-enabled systemd-resolved >& /dev/null && sudo systemctl disable systemd-resolved
+```
+
+### Debian
+
+Normally it should be similar to Ubuntu.
+

--- a/scripts/vagrant-setup-env.sh
+++ b/scripts/vagrant-setup-env.sh
@@ -25,11 +25,11 @@ cd $GOPATH/src/github.com/kinvolk/kube-spawn
 
 go get -u github.com/containernetworking/plugins/plugins/...
 
-make all
+DOCKERIZED=n make all
 
 sudo machinectl show-image coreos || sudo machinectl pull-raw --verify=no https://alpha.release.core-os.net/amd64-usr/current/coreos_developer_container.bin.bz2 coreos
 
-sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=v1.7.5 create --nodes=2
-sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn --kubernetes-version=v1.7.5 start
+sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn create --nodes=2
+sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn start
 EOF
 fi


### PR DESCRIPTION
In Vagrantfile, do not install Kubernetes and docker. On the testing host machine, we don't necessarily need to install Kubernetes and docker. Kubernetes binaries are downloaded anyway under `/var/lib/kube-spawn`, and docker isn't used at all.

Also upgrade Ubuntu to 17.10 (Artful), and disable the stub resolver of systemd-resolved to avoid DNS resolving issues inside nspawn containers.