### PR TITLE
pkg/nspawntool: fix panic when running more nodes than defined

### DIFF
--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -36,6 +36,11 @@ import (
 )
 
 func Run(cfg *config.ClusterConfiguration, mNo int) error {
+	// This check is necessary to avoid panic with "index out of range".
+	if mNo > len(cfg.Machines)-1 {
+		return fmt.Errorf("cannot get a machine kubespawn%d", mNo)
+	}
+
 	if cfg.Machines[mNo].Running {
 		return nil
 	}


### PR DESCRIPTION
The command `start` panics with `index out of range`, when the number specified in the `node` variable in `kspawn.toml` is greater than the actual number of nodes.

To avoid the panic, we should check for the actual length of the slice of nodes.

Fixes https://github.com/kinvolk/kube-spawn/issues/183