### PR TITLE
Fix colliding machine names when running multiple clusters

### DIFF
--- a/cmd/kube-spawn/start.go
+++ b/cmd/kube-spawn/start.go
@@ -68,7 +68,7 @@ func doStart(cfg *config.ClusterConfiguration, skipInit bool) {
 	for i := 0; i < cfg.Nodes; i++ {
 		go func(i int) {
 			defer wg.Done()
-			log.Printf("waiting for machine %q to start up", config.MachineName(i))
+			log.Printf("waiting for machine %q to start up", config.MachineName(cfg.Name, i))
 			if err := nspawntool.Run(cfg, i); err != nil {
 				log.Print(errors.Wrap(err, "failed to start machine"))
 				return

--- a/pkg/bootstrap/scripts.go
+++ b/pkg/bootstrap/scripts.go
@@ -51,7 +51,7 @@ func GenerateScripts(cfg *config.ClusterConfiguration) error {
 
 	// create empty config dirs for all nodes
 	for i := 0; i < cfg.Nodes; i++ {
-		rootDir := path.Join(cfg.KubeSpawnDir, cfg.Name, config.MachineName(i), "rootfs")
+		rootDir := path.Join(cfg.KubeSpawnDir, cfg.Name, config.MachineName(cfg.Name, i), "rootfs")
 		if err := fs.CreateDir(path.Join(rootDir, "etc")); err != nil {
 			return err
 		}

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -133,7 +133,7 @@ func SetDefaults_RuntimeConfiguration(cfg *ClusterConfiguration) error {
 	// TODO: can this be moved to the runtime functions below?
 	cfg.Machines = make([]MachineConfiguration, cfg.Nodes)
 	for i := 0; i < cfg.Nodes; i++ {
-		cfg.Machines[i].Name = MachineName(i)
+		cfg.Machines[i].Name = MachineName(cfg.Name, i)
 		mountPath := path.Join(cfg.KubeSpawnDir, cfg.Name, cfg.Machines[i].Name, "mount")
 
 		var pm Pathmap

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -31,11 +31,11 @@ import (
 const (
 	Filename = "kspawn.toml"
 
-	machineNameTemplate = "kubespawn%d"
+	machineNameTemplate = "kubespawn%s%d"
 )
 
-func MachineName(no int) string {
-	return fmt.Sprintf(machineNameTemplate, no)
+func MachineName(clusterName string, no int) string {
+	return fmt.Sprintf(machineNameTemplate, clusterName, no)
 }
 
 // TODO: this is not enough.


### PR DESCRIPTION
Machines and their images in `/var/lib/machines` get a name like:  
`kubespawndefault0`, `default` becomes the cluster name

Fixes #187