### PR TITLE
cmd/kube-spawn: remove cni config when destroying a cluster

### DIFF
--- a/cmd/kube-spawn/destroy.go
+++ b/cmd/kube-spawn/destroy.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
 	"github.com/kinvolk/kube-spawn/pkg/config"
 )
 
@@ -55,5 +56,15 @@ func doDestroy(cfg *config.ClusterConfiguration) {
 	if err := os.RemoveAll(cDir); err != nil {
 		log.Fatal(errors.Wrapf(err, "error removing cluster dir at %q", cDir))
 	}
+	RemoveCniConfig()
 	log.Printf("%q destroyed", cfg.Name)
+}
+
+func RemoveCniConfig() {
+	if err := os.RemoveAll(bootstrap.VarLibCniDir); err != nil {
+		log.Printf("cannot remove %q: %v", bootstrap.VarLibCniDir, err)
+	}
+	if err := os.RemoveAll(bootstrap.NspawnNetPath); err != nil {
+		log.Printf("cannot remove %q: %v", bootstrap.NspawnNetPath, err)
+	}
 }

--- a/pkg/bootstrap/cninet.go
+++ b/pkg/bootstrap/cninet.go
@@ -31,6 +31,8 @@ const LoopbackNetConf string = `
     "type": "loopback"
 }`
 
+const VarLibCniDir string = "/var/lib/cni/networks/kube-spawn-net"
+
 func writeNetConf(fpath, content string) error {
 	if _, err := os.Stat(fpath); os.IsExist(err) {
 		return nil


### PR DESCRIPTION
Let's make `./kube-spawn destroy` removes every CNI configuration file under `/var/lib/cni/networks/kube-spawn-net` as well as `/etc/cni/net.d/10-kube-spawn-net.conf`.

Fixes https://github.com/kinvolk/kube-spawn/issues/11