### PR TITLE
pkg/script: change Docker config to use overlay2

### DIFF
--- a/pkg/script/docker-daemon-config.go
+++ b/pkg/script/docker-daemon-config.go
@@ -8,6 +8,6 @@ const DockerDaemonConfig = `{
     "runtimes": {
         "custom": { "path": "/usr/bin/kube-spawn-runc" }
     },
-    "storage-driver": "overlay"
+    "storage-driver": "overlay2"
 }
 `


### PR DESCRIPTION
`overlay` is the old/deprecated overlayfs driver and does not work out
on top of btrfs, leading kube-spawn to fail out of the box when it
initialises a cluster on top of a btrfs filesystem.