### PR TITLE
Makefile: add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PREFIX ?= /usr
 BINDIR ?= ${PREFIX}/bin
 UID=$(shell id -u)
 
-.PHONY: all clean dep
+.PHONY: all clean dep install
 
 VERSION=$(shell git describe --tags --always --dirty)
 
@@ -37,3 +37,6 @@ clean:
 		cnispawn \
 		kube-spawn \
 		kube-spawn-runc
+
+install:
+	install cni-noop cnispawn kube-spawn kube-spawn-runc "$(BINDIR)"


### PR DESCRIPTION
This is to easily put the built binaries somewhere in `PATH`. Makes
use of the otherwise unused `BINDIR` variable.

The binaries are placed in `/usr/bin` by default. To alter the target
directory, override either `PREFIX` or `BINDIR` variable, like in
`make PREFIX=/usr/local install`.