### PR TITLE
pkg: clean up unused functions

### DIFF
--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -18,7 +18,6 @@ package bootstrap
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -49,29 +48,6 @@ const (
 type Node struct {
 	Name string
 	IP   string
-}
-
-func GetNodeName(no int) string {
-	return fmt.Sprintf(containerNameTemplate, no)
-}
-
-func NewNode(baseImage, machine string) error {
-	var buf bytes.Buffer
-
-	machinectlPath, err := exec.LookPath("machinectl")
-	if err != nil {
-		return err
-	}
-
-	clone := exec.Cmd{
-		Path:   machinectlPath,
-		Args:   []string{"machinectl", "clone", baseImage, machine},
-		Stderr: &buf,
-	}
-	if err := clone.Run(); err != nil {
-		return fmt.Errorf("error running machinectl: %s", buf.String())
-	}
-	return nil
 }
 
 func GetRunningNodes() ([]Node, error) {
@@ -161,20 +137,6 @@ func GetIPAddressLegacy(mach string) (string, error) {
 	}
 
 	return "", err
-}
-
-func IsNodeRunning(nodeName string) bool {
-	var err error
-	var runNodes []Node
-	if runNodes, err = GetRunningNodes(); err != nil {
-		return false
-	}
-	for _, n := range runNodes {
-		if strings.TrimSpace(nodeName) == strings.TrimSpace(n.Name) {
-			return true
-		}
-	}
-	return false
 }
 
 func PoolImageExists() bool {

--- a/pkg/bootstrap/util.go
+++ b/pkg/bootstrap/util.go
@@ -28,22 +28,10 @@ import (
 )
 
 const (
-	tmpDir string = ".kube-spawn/default"
-
 	FsMagicAUFS     = 0x61756673 // https://goo.gl/CBwx43
 	FsMagicECRYPTFS = 0xF15F     // https://goo.gl/4akUXJ
 	FsMagicZFS      = 0x2FC12FC1 // https://goo.gl/xTvzO5
 )
-
-func CreateSharedTmpdir() {
-	if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
-		os.MkdirAll(tmpDir, os.ModePerm)
-		// optional tmpfs
-		// if err := syscall.Mount("tmpfs", tmpDir, "tmpfs", syscall.MS_NOEXEC|syscall.MS_NOSUID|syscall.MS_NODEV, "size=10m"); err != nil {
-		// 	return err
-		// }
-	}
-}
 
 // PathSupportsOverlay checks whether the given path is compatible with OverlayFS.
 // This method also calls isOverlayfsAvailable().

--- a/pkg/script/kubeadm-extra-runtime.go
+++ b/pkg/script/kubeadm-extra-runtime.go
@@ -1,9 +1,5 @@
 package script
 
-import (
-	"bytes"
-)
-
 const kubeadmExtraRuntimeTmpl string = `
 {{ if .RktRuntime -}}--container-runtime=remote \
 --container-runtime-endpoint={{.RuntimeEndpoint}}{{- end}} \
@@ -18,8 +14,4 @@ type KubeadmExtraRuntimeOpts struct {
 	RktRuntime      bool
 	RuntimeEndpoint string
 	RequestTimeout  string
-}
-
-func GetKubeadmExtraRuntime(opts KubeadmExtraRuntimeOpts) (*bytes.Buffer, error) {
-	return render(kubeadmExtraRuntimeTmpl, opts)
 }


### PR DESCRIPTION
Clean up unused functions except for `CheckValidFile` which will be probably used later again.

These are detected by `codecoroner funcs --ignore vendor ./...`.