### PR TITLE
start: increase timeout

### DIFF
--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -110,7 +110,7 @@ func Run(cfg *config.ClusterConfiguration, mNo int) error {
 }
 
 func waitMachinesRunning(machineName string) error {
-	for retries := 0; retries <= 15; retries++ {
+	for retries := 0; retries <= 30; retries++ {
 		if machinetool.IsRunning(machineName) {
 			return nil
 		}


### PR DESCRIPTION
Testing on Ubuntu 17.10 on GCE with only 2 vCPUs, `kube-spawn start` fails by timeout:

```
failed to start machine: timeout waiting for "kubespawndefault2" to start
not all machines started
```

I couldn't get it to pass this step without increasing the timeout.
