### PR TITLE
README: add an instruction to install binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ $ go get -d github.com/kinvolk/kube-spawn
 $ cd $GOPATH/src/github.com/kinvolk/kube-spawn
 $ make all
 
+# (optional) Install binaries under a system directory.
+# The install prefix defaults to /usr, which you can override with an env
+# variable $PREFIX, like "make PREFIX=/usr/local install".
+$ sudo make install
+
 $ export CNI_PATH=$GOPATH/bin
 
 # This generated a default 3 nodes cluster configuration


### PR DESCRIPTION
Since https://github.com/kinvolk/kube-spawn/pull/199, it is possible to install kube-spawn binaries under a system directory.

Fixes https://github.com/kinvolk/kube-spawn/issues/203 