### PR TITLE
Some fixes for #198

### DIFF
--- a/pkg/bootstrap/bridge.go
+++ b/pkg/bootstrap/bridge.go
@@ -18,8 +18,8 @@ package bootstrap
 
 import (
 	"os"
-	"os/exec"
 
+	"github.com/kinvolk/kube-spawn/pkg/utils"
 	"github.com/vishvananda/netlink"
 )
 
@@ -32,7 +32,7 @@ func EnsureBridge() error {
 		return nil
 	}
 
-	cmd := exec.Command("cni-noop")
+	cmd := utils.Command("cni-noop")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"time"
@@ -33,6 +32,7 @@ import (
 
 	"github.com/kinvolk/kube-spawn/pkg/config"
 	"github.com/kinvolk/kube-spawn/pkg/machinetool"
+	"github.com/kinvolk/kube-spawn/pkg/utils"
 )
 
 func Run(cfg *config.ClusterConfiguration, mNo int) error {
@@ -69,7 +69,7 @@ func Run(cfg *config.ClusterConfiguration, mNo int) error {
 	args = append(args, optionsFromBindmountConfig(cfg.Bindmount)...)
 	args = append(args, optionsFromBindmountConfig(cfg.Machines[mNo].Bindmount)...)
 
-	c := exec.Command("cnispawn", args...)
+	c := utils.Command("cnispawn", args...)
 	c.Stderr = os.Stderr
 
 	// log.Printf(">>> runnning: %q", strings.Join(c.Args, " "))

--- a/pkg/utils/command.go
+++ b/pkg/utils/command.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func isExecBinary(path string) bool {
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	if fi.IsDir() {
+		return false
+	}
+	return (fi.Mode().Perm() & 0111) == 0
+}
+
+// Command creates an exec.Cmd instance like exec.Command does - it
+// fills only Path and Args fields. But the difference is that the
+// binary in current working directory takes precedence over the
+// binary in PATH.
+func Command(name string, arg ...string) *exec.Cmd {
+	cmd := &exec.Cmd{
+		Path: name,
+		Args: append([]string{name}, arg...),
+	}
+	if filepath.Base(name) == name {
+		if isExecBinary(name) {
+			return cmd
+		}
+		if lp, err := exec.LookPath(name); err == nil {
+			cmd.Path = lp
+		}
+	}
+	return cmd
+}


### PR DESCRIPTION
`exec.Command` was not actually falling back to executing binaries in current working directory but it was setting an internal error which was returned at the time `cmd.Start` was called.

These two commits fixes that, so kube-spawn prefers to execute the binaries in current working directory if they exist and falls back to searching `PATH` for them.