### PR TITLE
cni config: create config before using it

### DIFF
--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -357,12 +357,12 @@ func runBtrfsDisableQuota() error {
 }
 
 func EnsureRequirements(cfg *config.ClusterConfiguration) error {
-	if err := EnsureBridge(); err != nil {
-		return errors.Wrap(err, "error checking CNI bridge")
-	}
 	// TODO: should be moved to pkg/config/defaults.go
 	if err := WriteNetConf(); err != nil {
 		errors.Wrap(err, "error writing CNI configuration")
+	}
+	if err := EnsureBridge(); err != nil {
+		return errors.Wrap(err, "error checking CNI bridge")
 	}
 	// check if container linux base image exists
 	log.Printf("checking base image")


### PR DESCRIPTION
'create' fails because it attemps to use the CNI configuration file
before it is created.

Symptoms:
```
$ sudo -E ./kube-spawn create --nodes=3
creating cluster environment "default"
spawning kubernetes version "v1.7.5"
pulling coreos image...
ensuring environment
2017/11/12 14:48:31 open /etc/cni/net.d/10-kube-spawn-net.conf: no such file or directory
error checking CNI bridge: exit status 1
```
Fixes https://github.com/kinvolk/kube-spawn/issues/206