### PR TITLE
pkg/bootstrap: turn on stdout/err when pulling an image

### DIFF
--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -764,9 +764,11 @@ func pullRawCoreosImage() error {
 	}
 
 	cmd := exec.Cmd{
-		Path: cmdPath,
-		Args: args,
-		Env:  os.Environ(),
+		Path:   cmdPath,
+		Args:   args,
+		Env:    os.Environ(),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
 	}
 
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
When running `machinectl pull-raw`, we need to set Stdout to os.Stdout, as well as Stderr to os.Stderr, to get useful output messages printed on the screen. So far only a simple message "pulling coreos image..." has been printed. With this change, we can have precise messages like that:

```
Pulling 'https://alpha.release.core-os.net/amd64-usr/current/coreos_developer_container.bin.bz2',
Saving as 'coreos'.
```

Partly covers https://github.com/kinvolk/kube-spawn/issues/205