### PR TITLE
cmd/kube-spawn: retry to remove image until it succeeds

### DIFF
--- a/cmd/kube-spawn/stop.go
+++ b/cmd/kube-spawn/stop.go
@@ -121,9 +121,16 @@ func removeImages(cfg *config.ClusterConfiguration) {
 		go func(i int) {
 			defer wg.Done()
 			// clean up image
-			if machinetool.ImageExists(cfg.Machines[i].Name) {
-				if err := removeImage(cfg.Machines[i].Name); err != nil {
-					log.Print(err)
+			machName := cfg.Machines[i].Name
+			if machinetool.ImageExists(machName) {
+				for retries := 0; retries < 15; retries++ {
+					if err := removeImage(machName); err != nil {
+						log.Printf("failed to remove image %q: %v. retrying...", machName, err)
+						time.Sleep(500 * time.Millisecond)
+						continue
+					}
+					log.Printf("successfully removed image %q", machName)
+					break
 				}
 			}
 		}(i)


### PR DESCRIPTION
Sometimes `kube-spawn stop` succeeded, but afterwards kube-spawn is not able to remove `kubespawndefault*` images, because of errors like `device or resource busy`. That makes the next round of starting clusters fail because of the remaining images.

This happens simply because it takes some time until nspawn containers can release every resource. So we need to retry to remove image until it succeeds, up to 15 * 0.5 sec = 7.5 sec.

Fixes https://github.com/kinvolk/kube-spawn/issues/213