### PR TITLE
[RFC] list: indicate when environments are invalid

### DIFF
--- a/cmd/kube-spawn/create.go
+++ b/cmd/kube-spawn/create.go
@@ -82,7 +82,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 }
 
 func doCreate() {
-	cfg, err := config.LoadConfig()
+	cfg, err := config.LoadConfig(viper.GetString("cluster-name"))
 	if err != nil {
 		// ignore if config not found
 		// it means we started from scratch and need to generate one

--- a/cmd/kube-spawn/kube-spawn.go
+++ b/cmd/kube-spawn/kube-spawn.go
@@ -68,7 +68,7 @@ func main() {
 }
 
 func loadConfig() *config.ClusterConfiguration {
-	cfg, err := config.LoadConfig()
+	cfg, err := config.LoadConfig(viper.GetString("cluster-name"))
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "error loading config"))
 	}

--- a/cmd/kube-spawn/list.go
+++ b/cmd/kube-spawn/list.go
@@ -26,9 +26,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/kinvolk/kube-spawn/pkg/config"
 )
 
-const tableFmt = "%-10s  %s"
+const tableFmt = "%-18s  %s"
 
 var (
 	listCmd = &cobra.Command{
@@ -62,12 +64,17 @@ func runList(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if fi.IsDir() {
-			found = append(found, []string{
-				fi.Name(),
-				fi.ModTime().Format(time.Stamp),
-			})
+		if !fi.IsDir() {
+			continue
 		}
+		clusterName := fi.Name()
+		if _, err := config.LoadConfig(clusterName); err != nil {
+			clusterName += " [INVALID]"
+		}
+		found = append(found, []string{
+			clusterName,
+			fi.ModTime().Format(time.Stamp),
+		})
 	}
 
 	if len(found) < 1 {

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -50,8 +50,8 @@ func RunningMachines(cfg *ClusterConfiguration) int {
 	return n
 }
 
-func LoadConfig() (*ClusterConfiguration, error) {
-	cfgFile := path.Join(viper.GetString("dir"), viper.GetString("cluster-name"), Filename)
+func LoadConfig(clusterName string) (*ClusterConfiguration, error) {
+	cfgFile := path.Join(viper.GetString("dir"), clusterName, Filename)
 	viper.SetConfigFile(cfgFile)
 
 	var err error


### PR DESCRIPTION
Before kube-spawn supported multiple cluster environments,
/var/lib/kube-spawn used to contain directory such as "etc", "k8s" etc.
When updating to a newer kube-spawn, this is mixed with the different
environments. This makes the "kube-spawn list" command confused.

This patch makes it more obvious that "k8s" is not a real cluster name:
```
$ sudo -E kube-spawn list
ENV NAME            LAST MODIFIED
default             Nov 16 17:43:05
etc [INVALID]       Oct  9 16:39:36
extras [INVALID]    Sep 22 15:03:21
k8s [INVALID]       Oct  9 16:39:36
scripts [INVALID]   Sep 22 16:31:10

5 environment(s) found
```

To achieve this, the command list actually parses the kspawn.toml
configuration file and prints "[INVALID]" when the parsing fails. The
LoadConfig() function in 'pkg/config/utils.go' was changed to accept the
cluster name as parameter instead of using the viper flag. I think it's
better if code in 'pkg/' does not use viper in this way because
libraries should not have a clear API without hidden side-channels.
Besides, it will help when implementing a kube-spawn daemon with a gRPC
interface.