### PR TITLE
kubeadm join: fix TLS on Kubernetes >=1.9

### DIFF
--- a/pkg/nspawntool/kubeadm.go
+++ b/pkg/nspawntool/kubeadm.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
 	"github.com/kinvolk/kube-spawn/pkg/config"
 	"github.com/kinvolk/kube-spawn/pkg/machinetool"
+	"github.com/kinvolk/kube-spawn/pkg/utils"
 	"github.com/kinvolk/kube-spawn/pkg/utils/fs"
 	"github.com/pkg/errors"
 )
@@ -88,7 +89,18 @@ func JoinNode(cfg *config.ClusterConfiguration, mNo int) error {
 	}
 	joinCmd = append(joinCmd, []string{
 		"/usr/bin/kubeadm", "join", "--skip-preflight-checks",
-		"--token", cfg.Token,
-		cfg.Machines[0].IP + ":6443"}...)
+		"--token", cfg.Token}...)
+
+	// --discovery-token-unsafe-skip-ca-verification appeared in Kubernetes 1.8
+	// See: https://github.com/kubernetes/kubernetes/pull/49520
+	// It is mandatory since Kubernetes 1.9
+	// See: https://github.com/kubernetes/kubernetes/pull/55468
+	// Test is !<1.8 instead of >=1.8 in order to handle non-semver version 'latest'
+	if !utils.CheckVersionConstraint(cfg.KubernetesVersion, "<1.8") {
+		joinCmd = append(joinCmd, "--discovery-token-unsafe-skip-ca-verification")
+	}
+
+	joinCmd = append(joinCmd, cfg.Machines[0].IP+":6443")
+
 	return machinetool.Shell(shellOpts, cfg.Machines[mNo].Name, joinCmd...)
 }


### PR DESCRIPTION
kubeadm got a new option in version 1.8: `--discovery-token-unsafe-skip-ca-verification`
See: https://github.com/kubernetes/kubernetes/pull/49520

Since version 1.9, it became mandatory to either use it to skip verification, or to use `--discovery-token-ca-cert-hash=...`
See: https://github.com/kubernetes/kubernetes/pull/55468

Since kube-spawn is a developer tool used on one physical machine, use the former.
