### PR TITLE
Fix dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,25 +104,28 @@ $ cd $GOPATH/src/k8s.io/kubernetes
 $ build/run.sh make
 
 # Build a Hyperkube Docker image
-$ cd cluster/images/hyperkube
-$ make VERSION=latest
+$ git describe
+v1.8.5-beta.0
+$ make -C cluster/images/hyperkube VERSION=v1.8.5-beta.0-myfeature
 ```
 
-This will create a Docker image with a name `gcr.io/google-containers/hyperkube-amd64`.
+This will create a Docker image with a name `gcr.io/google-containers/hyperkube-amd64:v1.8.5-beta.0-myfeature`.
 To check if it is created correctly, do so:
 
 ```
 $ docker images | grep hyperkube-amd64
-gcr.io/google-containers/hyperkube-amd64               latest                        179a38ef4d78        45 hours ago        506 MB
+gcr.io/google-containers/hyperkube-amd64               v1.8.5-beta.0-myfeature                     8687537eff68        10 minutes ago      530 MB
 ```
 
 Assuming you have built `kube-spawn` and pulled the CoreOS image, do:
 
 ```
 # Spawn and provision nodes for the cluster
-$ sudo -E ./kube-spawn create --dev
-$ sudo -E ./kube-spawn start
+$ sudo -E ./kube-spawn create --dev -t v1.8.5-beta.0-myfeature -c myfeature
+$ sudo -E ./kube-spawn start -c myfeature
 ```
+
+For a specific example, see [doc/dev-workflow](doc/dev-workflow.md).
 
 ### Access a kube-spawn node
 

--- a/cmd/kube-spawn/create.go
+++ b/cmd/kube-spawn/create.go
@@ -38,7 +38,7 @@ var (
 If you change 'kspawn.toml' this needs to be run again.`,
 		Example: `
 # Create an environment to run a 3 node cluster initialized with components from $GOPATH/k8s.io/kubernetes
-$ sudo -E kube-spawn create --nodes 3 --dev
+$ sudo -E kube-spawn create --nodes 3 --dev -t mytag
 
 # Create a cluster environment using rkt as the container runtime
 # You can specify paths to the binaries necessary using environment variables (in case they are not in your PATH)
@@ -60,7 +60,8 @@ func init() {
 	// and call from the if uninitialized {} block below
 	//
 	createCmd.Flags().StringP("container-runtime", "r", "", "runtime to use for the spawned cluster (docker or rkt)")
-	createCmd.Flags().String("kubernetes-version", "", `version kubernetes used to initialize the cluster. Irrelevant if used wih --dev. Only accepts semantic version strings like "v1.7.5"`)
+	createCmd.Flags().String("kubernetes-version", "", `version kubernetes used to initialize the cluster. Irrelevant if used with --dev. Only accepts semantic version strings like "v1.7.5"`)
+	createCmd.Flags().StringP("hyperkube-tag", "t", "latest", `Docker tag of the hyperkube image to use. Only with --dev`)
 	createCmd.Flags().Bool("dev", false, "create a cluster from a local build of Kubernetes")
 	createCmd.Flags().IntP("nodes", "n", 0, "number of nodes to spawn")
 	createCmd.Flags().StringP("image", "i", "", "base image for nodes")

--- a/cmd/kube-spawn/start.go
+++ b/cmd/kube-spawn/start.go
@@ -102,7 +102,7 @@ func doStart(cfg *config.ClusterConfiguration, skipInit bool) {
 		}
 		var err error
 		for i := 0; i < distribution.PushImageRetries; i++ {
-			err = distribution.PushImage()
+			err = distribution.PushImage(cfg.HyperkubeTag)
 			if err == nil {
 				break
 			}

--- a/doc/dev-workflow.md
+++ b/doc/dev-workflow.md
@@ -1,0 +1,146 @@
+# Kubernetes development workflow example
+
+This article describes a step-by-step example of workflow that a Kubernetes developer might follow when patching Kubernetes.
+
+For the purpose of the article, we will write a new [admission controler](https://kubernetes.io/docs/admin/admission-controllers/) named `DenyAttach` that inconditionally denies all attaching to a container. The end result will be:
+
+```bash
+$ kubectl attach mypod-74c9fd65cb-n5hsg
+If you don't see a command prompt, try pressing enter.
+Error from server (Forbidden): pods "mypod-74c9fd65cb-n5hsg" is forbidden: cannot attach to a container, rejected by admission controller
+```
+
+The implementation of `DenyAttach` will be reusing code from the existing admission controller [DenyEscalatingExec](https://kubernetes.io/docs/admin/admission-controllers/#denyescalatingexec).
+
+## Compiling locally
+
+We will first fetch the [patch](https://github.com/kinvolk/kubernetes/commit/c117bd71672b2da7c7777cddf0287b07d29b90e5).
+
+```bash
+$ cd $GOPATH/src/k8s.io/kubernetes
+
+# Add git kinvolk remote if not already done
+$ git remote |grep -q kinvolk || git remote add kinvolk https://github.com/kinvolk/kubernetes
+
+# Fetch the branch
+$ git pull kinvolk alban/v1.8.5-beta.0-denyattach
+$ git checkout kinvolk/alban/v1.8.5-beta.0-denyattach
+
+# Build Kubernetes
+$ build/run.sh make
+
+# Build a Hyperkube Docker image with a tag
+$ make -C cluster/images/hyperkube VERSION=v1.8.5-beta.0-denyattach
+```
+
+docker images | grep hyperkube-amd64
+
+## Deploying your build on kube-spawn
+
+```
+# Spawn and provision nodes for the cluster
+$ sudo -E ./kube-spawn create --dev -t v1.8.5-beta.0-denyattach -c denyattach
+$ sudo -E ./kube-spawn start -c denyattach
+```
+
+## Testing the new DenyAttach admission controller
+
+```
+$ export KUBECONFIG=/var/lib/kube-spawn/denyattach/kubeconfig
+$ kubectl get nodes
+kubespawndenyattach0   Ready     master    1h        v1.8.5-beta.0.1+c117bd71672b2d-dirty
+kubespawndenyattach1   Ready     <none>    1h        v1.8.5-beta.0.1+c117bd71672b2d-dirty
+```
+
+Once all nodes are ready, deploy a simple pod:
+```
+kubectl run mypod --image=busybox --command -- /bin/sh -c 'while true ; do sleep 1 ; date ; done'
+```
+
+Get the name of your pod:
+```
+$ kubectl get pod
+NAME                     READY     STATUS    RESTARTS   AGE
+mypod-74c9fd65cb-n5hsg   1/1       Running   0          25m
+```
+
+Check that the pod works correctly but that attaching is not possible:
+```
+$ kubectl logs mypod-74c9fd65cb-n5hsg | tail -2
+Sun Nov 26 15:17:32 UTC 2017
+Sun Nov 26 15:17:33 UTC 2017
+$ kubectl attach mypod-74c9fd65cb-n5hsg
+If you don't see a command prompt, try pressing enter.
+Error from server (Forbidden): pods "mypod-74c9fd65cb-n5hsg" is forbidden: cannot attach to a container, rejected by admission controller
+```
+
+## Sharing the hyperkube image
+
+```
+docker tag gcr.io/google-containers/hyperkube-amd64:v1.8.5-beta.0-denyattach docker.io/kinvolk/hyperkube-amd64:v1.8.5-beta.0-denyattach
+docker push docker.io/kinvolk/hyperkube-amd64:v1.8.5-beta.0-denyattach
+```
+
+Then, this image can be tested by other developers.
+
+## Using an external hyperkube image
+
+Someone might not like the error message, saying "rejected by admission controller":
+Kubernetes has plenty of admission controllers and it does not say which one rejected the request.
+
+If someone develops a fix for the error message, you can pull that version and test it with kube-spawn without compiling Kubernetes yourself by naming the image in the same way a local build would do:
+
+```
+$ docker pull docker.io/kinvolk/hyperkube-amd64:v1.8.5-beta.0-denyattachfix
+$ docker tag docker.io/kinvolk/hyperkube-amd64:v1.8.5-beta.0-denyattachfix gcr.io/google-containers/hyperkube-amd64:v1.8.5-beta.0-denyattachfix
+```
+
+Then, you can start another kube-spawn cluster:
+```
+$ sudo -E ./kube-spawn create --dev -t v1.8.5-beta.0-denyattachfix -c denyattachfix
+$ sudo -E ./kube-spawn start -c denyattachfix
+```
+
+By running the same test as before, you could see the different error message:
+```
+$ kubectl attach mypod-74c9fd65cb-48d9m
+If you don't see a command prompt, try pressing enter.
+Error from server (Forbidden): pods "mypod-74c9fd65cb-48d9m" is forbidden: cannot attach to a container, rejected by DenyAttach
+```
+
+This new version of the patch is available on [github](https://github.com/kinvolk/kubernetes/commit/eb0c026372a67eb49bbf80aa619f10ee94527bac).
+
+### Limitations
+
+The hyperkube image contains the api server, the controller manager and the scheduler but not `kubeadm`.
+Therefore, if your patch makes changes in kubeadm, it has to be compiled locally: pulling a remote hyperkube image will not be enough.
+
+## Running several kube-spawn clusters in parallel
+
+You can build several hyperkube versions and run several kube-spawn clusters in parallel by giving them different names with the `-c` option.
+
+```
+$ KUBECONFIG=/var/lib/kube-spawn/denyattach/kubeconfig kubectl get pod
+NAME                     READY     STATUS    RESTARTS   AGE
+mypod-74c9fd65cb-n5hsg   1/1       Running   0          59m
+
+$ KUBECONFIG=/var/lib/kube-spawn/denyattachfix/kubeconfig kubectl get pod
+NAME                     READY     STATUS    RESTARTS   AGE
+mypod-74c9fd65cb-48d9m   1/1       Running   0          3m
+...
+
+$ machinectl
+MACHINE                          CLASS     SERVICE        OS     VERSION  ADDRESSES
+3436870bac346e5ad5a7699b92c21834 container docker         alpine 3.4.6    172.17.0.2...
+kubespawndenyattach0             container systemd-nspawn coreos 1492.1.0 10.22.0.2...
+kubespawndenyattach1             container systemd-nspawn coreos 1492.1.0 10.22.0.3...
+kubespawndenyattachfix0          container systemd-nspawn coreos 1492.1.0 10.22.0.4...
+kubespawndenyattachfix1          container systemd-nspawn coreos 1492.1.0 10.22.0.5...
+
+5 machines listed.
+```
+
+### Limitations
+
+If your cluster name finishes with a digit, the node names might conflict.
+To avoid this, I used the cluster names "denyattach" and "denyattachfix".

--- a/pkg/bootstrap/scripts.go
+++ b/pkg/bootstrap/scripts.go
@@ -97,7 +97,9 @@ func writeKubeadmConfig(cfg *config.ClusterConfiguration) error {
 	kubeadmConf := path.Join(rootfsPath(cfg), script.KubeadmConfigPath)
 
 	buf, err := script.GetKubeadmConfig(script.KubeadmYmlOpts{
+		DevCluster:        cfg.DevCluster,
 		KubernetesVersion: cfg.KubernetesVersion,
+		HyperkubeTag:      cfg.HyperkubeTag,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "error generating %q", kubeadmConf)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -37,7 +37,8 @@ type ClusterConfiguration struct {
 
 	// DevCluster indicates if we should run
 	// from a local kubernetes build
-	DevCluster bool `toml:"dev" mapstructure:"dev"`
+	DevCluster   bool   `toml:"dev" mapstructure:"dev"`
+	HyperkubeTag string `toml:"hyperkube-tag" mapstructure:"hyperkube-tag"`
 
 	RuntimeConfiguration RuntimeConfiguration `toml:"runtime-config,omitempty" mapstructure:"runtime-config"`
 

--- a/pkg/distribution/registry.go
+++ b/pkg/distribution/registry.go
@@ -98,7 +98,7 @@ func StartRegistry() error {
 	return cli.ContainerStart(ctx, "registry", types.ContainerStartOptions{})
 }
 
-func PushImage() error {
+func PushImage(tag string) error {
 	cli, err := client.NewEnvClient()
 	if err != nil {
 		return err
@@ -106,8 +106,8 @@ func PushImage() error {
 
 	if err := cli.ImageTag(
 		context.Background(),
-		"gcr.io/google-containers/hyperkube-amd64",
-		"10.22.0.1:5000/hyperkube-amd64",
+		"gcr.io/google-containers/hyperkube-amd64:"+tag,
+		"10.22.0.1:5000/hyperkube-amd64:"+tag,
 	); err != nil {
 		return err
 	}

--- a/pkg/nspawntool/kubeadm.go
+++ b/pkg/nspawntool/kubeadm.go
@@ -1,6 +1,7 @@
 package nspawntool
 
 import (
+	"fmt"
 	"path"
 	"strings"
 
@@ -19,8 +20,9 @@ func InitializeMaster(cfg *config.ClusterConfiguration) error {
 	var initCmd []string
 	var shellOpts string
 	if cfg.DevCluster {
-		// TODO: remove this or implement config for it
-		shellOpts = `--setenv=KUBE_HYPERKUBE_IMAGE="10.22.0.1:5000/hyperkube-amd64"`
+		// KUBE_HYPERKUBE_IMAGE is used in old kubeadm versions. For new kubeadm >= 1.8,
+		// we set 'unifiedControlPlaneImage' in kubeadm.yml, see pkg/script/kubeadm-config.go
+		shellOpts = fmt.Sprintf(`--setenv=KUBE_HYPERKUBE_IMAGE="10.22.0.1:5000/hyperkube-amd64:%s"`, cfg.HyperkubeTag)
 	}
 	initCmd = append(initCmd, []string{
 		"/usr/bin/kubeadm", "init", "--skip-preflight-checks",

--- a/pkg/script/kubeadm-config.go
+++ b/pkg/script/kubeadm-config.go
@@ -13,10 +13,15 @@ apiServerExtraArgs:
 controllerManagerExtraArgs:
 kubernetesVersion: {{.KubernetesVersion}}
 schedulerExtraArgs:
+{{if .DevCluster -}}
+unifiedControlPlaneImage: 10.22.0.1:5000/hyperkube-amd64:{{.HyperkubeTag}}
+{{- end }}
 `
 
 type KubeadmYmlOpts struct {
+	DevCluster        bool
 	KubernetesVersion string
+	HyperkubeTag      string
 }
 
 func GetKubeadmConfig(opts KubeadmYmlOpts) (*bytes.Buffer, error) {


### PR DESCRIPTION
Add `--hyperkube-tag` (or `-t`) on `kube-spawn create` to specify which hyperkube Docker image to use. This is useful to compile different versions of Kubernetes and test them in parallel. `doc/dev-workflow.md` explains in more details how to use it.

kube-spawn will start a `registry` container and push the hyperkube image there under the name `10.22.0.1:5000/hyperkube-amd64:$TAG`. Then, kubeadm will pick that image.

Use the `unifiedControlPlaneImage` option in the kubeadm configuration file (>= 1.8) in addition to the old environment variable `$KUBE_HYPERKUBE_IMAGE` (< 1.8). This means `--dev` cannot be used anymore on 1.7 branches, but the 1.7 releases still work so it should not be a problem.

The dev workflow is now documented in doc/dev-workflow.md

Fixes https://github.com/kinvolk/kube-spawn/issues/188

-----

TODO
- [x] needs rebase after #222 is merged
- [x] pkg/script/kubeadm-config.go should only add `unifiedControlPlaneImage` with `--dev`

/cc @blixtra 