### PR TITLE
vagrant: Expose apiserver outside the VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
 
   # Fedora 26
   config.vm.define "fedora", primary: true do |fedora|
-    config.vm.provision "shell", inline: "dnf install -y btrfs-progs git go iptables libselinux-utils polkit qemu-img systemd-container"
+    config.vm.provision "shell", inline: "dnf install -y btrfs-progs git go iptables libselinux-utils polkit qemu-img rinetd systemd-container"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
   # Ubuntu 17.10 (Artful)
   config.vm.define "ubuntu", autostart: false do |ubuntu|
     config.vm.box = "generic/ubuntu1710"
-    config.vm.provision "shell", inline: "apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y btrfs-progs git golang iptables policykit-1 qemu-utils selinux-utils systemd-container"
+    config.vm.provision "shell", inline: "apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y btrfs-progs git golang iptables policykit-1 qemu-utils rinetd selinux-utils systemd-container"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
@@ -63,7 +63,7 @@ Vagrant.configure("2") do |config|
   # Debian testing
   config.vm.define "debian", autostart: false do |debian|
     config.vm.box = "debian/testing64"
-    config.vm.provision "shell", inline: "echo deb http://httpredir.debian.org/debian unstable main >> /etc/apt/sources.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y btrfs-progs git golang iptables policykit-1 qemu-utils selinux-utils systemd-container"
+    config.vm.provision "shell", inline: "echo deb http://httpredir.debian.org/debian unstable main >> /etc/apt/sources.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y btrfs-progs git golang iptables policykit-1 qemu-utils rinetd selinux-utils systemd-container"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
@@ -77,4 +77,6 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
     config.vm.provision "shell", env: {"VUSER" => "vagrant"}, path: "scripts/vagrant-mod-env.sh"
   end
+
+  config.vm.network "forwarded_port", guest: 6443, host: 6443
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,8 +38,11 @@ Vagrant.configure("2") do |config|
     # with correct owner/group. Maybe a vagrant issue?
     config.vm.provision "shell", inline: "mkdir -p /home/vagrant/go ; chown -R vagrant:vagrant /home/vagrant/go"
 
-    config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
+    config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go", "KUBESPAWN_REDIRECT_TRAFFIC" => ENV["KUBESPAWN_REDIRECT_TRAFFIC"]}, privileged: false, path: "scripts/vagrant-setup-env.sh"
     config.vm.provision "shell", env: {"VUSER" => "vagrant"}, path: "scripts/vagrant-mod-env.sh"
+    if ENV["KUBESPAWN_AUTOBUILD"] <=> "true"
+      config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go", "KUBESPAWN_REDIRECT_TRAFFIC" => ENV["KUBESPAWN_REDIRECT_TRAFFIC"]}, inline: "bash /home/vagrant/build.sh"
+    end
   end
 
   # Ubuntu 17.10 (Artful)
@@ -56,8 +59,11 @@ Vagrant.configure("2") do |config|
       rsync__exclude: ".kube-spawn/"
 
     config.vm.provision "shell", inline: "mkdir -p /home/vagrant/go ; chown -R vagrant:vagrant /home/vagrant/go"
-    config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
+    config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go", "KUBESPAWN_REDIRECT_TRAFFIC" => ENV["KUBESPAWN_REDIRECT_TRAFFIC"]}, privileged: false, path: "scripts/vagrant-setup-env.sh"
     config.vm.provision "shell", env: {"VUSER" => "vagrant"}, path: "scripts/vagrant-mod-env.sh"
+    if ENV["KUBESPAWN_AUTOBUILD"] <=> "true"
+      config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go", "KUBESPAWN_REDIRECT_TRAFFIC" => ENV["KUBESPAWN_REDIRECT_TRAFFIC"]}, inline: "bash /home/vagrant/build.sh"
+    end
   end
 
   # Debian testing
@@ -74,8 +80,11 @@ Vagrant.configure("2") do |config|
       rsync__exclude: ".kube-spawn/"
 
     config.vm.provision "shell", inline: "mkdir -p /home/vagrant/go ; chown -R vagrant:vagrant /home/vagrant/go"
-    config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go"}, privileged: false, path: "scripts/vagrant-setup-env.sh"
+    config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go", "KUBESPAWN_REDIRECT_TRAFFIC" => ENV["KUBESPAWN_REDIRECT_TRAFFIC"]}, privileged: false, path: "scripts/vagrant-setup-env.sh"
     config.vm.provision "shell", env: {"VUSER" => "vagrant"}, path: "scripts/vagrant-mod-env.sh"
+    if ENV["KUBESPAWN_AUTOBUILD"] <=> "true"
+      config.vm.provision "shell", env: {"GOPATH" => "/home/vagrant/go", "KUBESPAWN_REDIRECT_TRAFFIC" => ENV["KUBESPAWN_REDIRECT_TRAFFIC"]}, inline: "bash /home/vagrant/build.sh"
+    end
   end
 
   config.vm.network "forwarded_port", guest: 6443, host: 6443

--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -1,5 +1,40 @@
 ## Testing `kube-spawn` with [Vagrant](https://www.vagrantup.com/)
 
+### With script
+
+There is a script called `vagrant-all.sh` which does the following things:
+
+- sets up the Vagrant VM (`vagrant up`)
+- automatically builds the project during provisioning
+- runs the Kubernetes cluster
+- redirects traffic from 6443 port on VM to the container with k8s API
+- copies the `kubeconfig` to host
+
+```
+$ ./vagrant-all.sh
+```
+
+Then you can use the Kubernetes cluster both from inside the VM:
+
+```
+$ vagrant ssh
+$ kubectl get nodes
+NAME                STATUS    AGE       VERSION
+kubespawndefault0   Ready     12m       v1.7.5
+kubespawndefault1   Ready     11m       v1.7.5
+```
+
+or from host, if you have `kubectl` installed on it:
+
+```
+$ kubectl get nodes
+NAME                STATUS    AGE       VERSION
+kubespawndefault0   Ready     12m       v1.7.5
+kubespawndefault1   Ready     11m       v1.7.5
+```
+
+### Manually
+
 The provided Vagrantfile is used to test `kube-spawn` on various Linux distributions.
 
 ```
@@ -7,3 +42,10 @@ $ vagrant up
 $ vagrant ssh
 $ ./build.sh    # sets up environment, runs build and setup/init command
 ```
+
+You can set the following environment variables:
+
+- `KUBESPAWN_AUTOBUILD` - runs `build.sh` script (which builds kube-spawn) during machine
+  provisioning
+- `KUBESPAWN_REDIRECT_TRAFFIC` - redirects traffic from 6443 port on VM to the container
+  with k8s API

--- a/scripts/vagrant-setup-env.sh
+++ b/scripts/vagrant-setup-env.sh
@@ -31,5 +31,26 @@ sudo machinectl show-image coreos || sudo machinectl pull-raw --verify=no https:
 
 sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn create --nodes=2
 sudo GOPATH=$GOPATH CNI_PATH=$GOPATH/bin ./kube-spawn start
+
+if [ "\$KUBESPAWN_REDIRECT_TRAFFIC" == "true" ]; then
+	# Redirect traffic from the VM to kube-apiserver inside container
+	APISERVER_IP_PORT=\$(grep server /var/lib/kube-spawn/default/kubeconfig | awk '{print \$2;}' | perl -pe 's/(https|http):\/\///g')
+	APISERVER_IP=\$(echo \$APISERVER_IP_PORT | perl -pe 's/:\d*$//g')
+	APISERVER_PORT=\$(echo \$APISERVER_IP_PORT | perl -pe 's/^[\d.]+://g')
+	echo "0.0.0.0 \$APISERVER_PORT \$APISERVER_IP \$APISERVER_PORT" | sudo tee /etc/rinetd.conf > /dev/null
+	sudo systemctl enable rinetd
+	sudo systemctl start rinetd
+
+	# Generate kubeconfig
+	cd /home/vagrant
+	VAGRANT_IP=\$(ip addr show eth0 | grep "inet\\b" | awk '{print \$2}' | cut -d/ -f1)
+	cp /var/lib/kube-spawn/default/kubeconfig .
+	perl -pi.back -e "s/\$APISERVER_IP/\$VAGRANT_IP/g;" kubeconfig
+	perl -pi.back -e "s/certificate-authority-data.*/insecure-skip-tls-verify: true/g;" kubeconfig
+fi
 EOF
 fi
+
+KUBERNETES_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+sudo curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl
+sudo chmod +x /usr/local/bin/kubectl

--- a/vagrant-all.sh
+++ b/vagrant-all.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eo pipefail
+
+export KUBESPAWN_AUTOBUILD="true"
+export KUBESPAWN_DISTRO=${KUBESPAWN_DISTRO:-fedora}
+export KUBESPAWN_REDIRECT_TRAFFIC="true"
+
+KUBESPAWN_PROVIDER=${KUBESPAWN_PROVIDER:-virtualbox}
+
+vagrant up $KUBESPAWN_DISTRO --provider=$KUBESPAWN_PROVIDER
+
+./vagrant-fetch-kubeconfig.sh
+
+export KUBECONFIG=$(pwd)/kubeconfig

--- a/vagrant-fetch-kubeconfig.sh
+++ b/vagrant-fetch-kubeconfig.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eo pipefail
+
+KUBESPAWN_DISTRO=${KUBESPAWN_DISTRO:-fedora}
+
+# The following command sometimes exists with status 1 when using vagrant-libvirt,
+# despite the fact that ssh config was generated successfully.
+vagrant ssh-config $KUBESPAWN_DISTRO > $(pwd)/.ssh_config || true
+scp -F $(pwd)/.ssh_config $(vagrant status | awk '/running/{print $1;}'):/home/vagrant/kubeconfig .


### PR DESCRIPTION
Introduce the KUBESPAWN_REDIRECT_TRAFFIC environment
variable to the build.sh script which redirects the
traffic incoming to the 6443 port in Vagrant VM to
the nspawn container with kube-apiserver.

Fixes #217