### PR TITLE
cmd/kube-spawn: bring back help message for KUBECONFIG

### DIFF
--- a/cmd/kube-spawn/start.go
+++ b/cmd/kube-spawn/start.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kinvolk/kube-spawn/pkg/distribution"
 	"github.com/kinvolk/kube-spawn/pkg/machinetool"
 	"github.com/kinvolk/kube-spawn/pkg/nspawntool"
+	"github.com/kinvolk/kube-spawn/pkg/utils"
 )
 
 var (
@@ -119,6 +120,8 @@ func doStart(cfg *config.ClusterConfiguration, skipInit bool) {
 		joinWorkerNodes(cfg)
 	}
 	log.Printf("cluster %q initialized", cfg.Name)
+	log.Println("Note: For kubectl to work, please set $KUBECONFIG:")
+	log.Printf("export KUBECONFIG=%s\n", utils.GetValidKubeConfig())
 	saveConfig(cfg)
 }
 


### PR DESCRIPTION
This help message for setting `$KUBECONFIG` at the end of `kube-spawn start` used to exist, but it was removed by https://github.com/kinvolk/kube-spawn/pull/161.
We should bring it back for better user experience.

Fixes https://github.com/kinvolk/kube-spawn/issues/230