### PR TITLE
pkg/utils: figure out kubeconfig path correctly with a cluster name

### DIFF
--- a/cmd/kube-spawn/start.go
+++ b/cmd/kube-spawn/start.go
@@ -121,7 +121,7 @@ func doStart(cfg *config.ClusterConfiguration, skipInit bool) {
 	}
 	log.Printf("cluster %q initialized", cfg.Name)
 	log.Println("Note: For kubectl to work, please set $KUBECONFIG:")
-	log.Printf("export KUBECONFIG=%s\n", utils.GetValidKubeConfig())
+	log.Printf("export KUBECONFIG=%s\n", utils.GetKubeconfigPath(cfg.KubeSpawnDir, cfg.Name))
 	saveConfig(cfg)
 }
 

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -29,19 +29,14 @@ import (
 )
 
 const (
-	kubeSpawnDir string = "/var/lib/kube-spawn"
-	ksHiddenDir  string = ".kube-spawn"
-	kcRelPath    string = "default/kubeconfig"
-	ksRelPath    string = "src/github.com/kinvolk/kube-spawn"
+	ksHiddenDir string = ".kube-spawn"
+	ksRelPath   string = "src/github.com/kinvolk/kube-spawn"
 )
 
 var (
 	homePath string = os.Getenv("HOME")
 	goPath   string = os.Getenv("GOPATH")
 	cniPath  string = os.Getenv("CNI_PATH")
-
-	kcUserPath   string = filepath.Join(ksHiddenDir, kcRelPath)
-	kcSystemPath string = filepath.Join(kubeSpawnDir, kcRelPath)
 )
 
 func CheckValidDir(inPath string) error {
@@ -74,7 +69,11 @@ func GetValidGoPath() (string, error) {
 	return goPath, nil
 }
 
-func GetValidKubeConfig() string {
+func GetKubeconfigPath(kubeSpawnDir, clusterName string) string {
+	kcRelPath := filepath.Join(clusterName, "kubeconfig")
+	kcUserPath := filepath.Join(ksHiddenDir, kcRelPath)
+	kcSystemPath := filepath.Join(kubeSpawnDir, kcRelPath)
+
 	kcPath := kcSystemPath
 	if err := CheckValidFile(kcPath); err != nil {
 		// fall back to $GOPATH/src/github.com/kinvolk/kube-spawn/.kube-spawn/default/kubeconfig


### PR DESCRIPTION
Now that kube-spawn is able to deal with multiple clusters, path to kubeconfig, `$KUBECONFIG`, can also differ depending on the cluster name. So `utils.GetValidKubeConfig()` should take a parameter for the cluster name, to compose path to kubeconfig correctly. For example, if the cluster's name is `mycluster`, KUBECONFIG will be `/var/lib/kube-spawn/mycluster/kubeconfig`.

Fixes https://github.com/kinvolk/kube-spawn/issues/230