### PR TITLE
pkg/config: fix a bug with kube-spawn-dir in kspawn.toml

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -27,7 +27,7 @@ const (
 // run kube-spawn
 //
 type ClusterConfiguration struct {
-	KubeSpawnDir string `toml:"-" mapstructure:"dir"`
+	KubeSpawnDir string `toml:"dir" mapstructure:"dir"`
 
 	Name              string `toml:"cluster-name" mapstructure:"cluster-name"`
 	ContainerRuntime  string `toml:"container-runtime" mapstructure:"container-runtime"`


### PR DESCRIPTION
We need to define a toml attribute "dir" for kube-spawn-dir, to be able to make use of a global option `-d' (or `--dir'). Otherwise the dir string is not stored in `kspawn.toml` at all, and as a result, the custom directory name cannot be set.

Fixes https://github.com/kinvolk/kube-spawn/issues/238