### PR TITLE
stop: remove images even if there's no machines to stop

### DIFF
--- a/cmd/kube-spawn/stop.go
+++ b/cmd/kube-spawn/stop.go
@@ -54,12 +54,12 @@ func doStop(cfg *config.ClusterConfiguration, force bool) {
 	}
 	log.Printf("%sstopping %d machines", forceTxt, len(cfg.Machines))
 
-	if !force && config.RunningMachines(cfg) == 0 {
+	if config.RunningMachines(cfg) != 0 {
+		stopMachines(cfg, force)
+	} else {
 		log.Print("nothing to stop")
-		return
 	}
 
-	stopMachines(cfg, force)
 	removeImages(cfg)
 
 	// clear cluster config


### PR DESCRIPTION
We should make sure we end up in a state where the cluster can be
started again, so we remove images and clear cluster configuration even
if there's no running machines.