### PR TITLE
cmd: fail when unnecessary parameters are given

### DIFF
--- a/cmd/kube-spawn/create.go
+++ b/cmd/kube-spawn/create.go
@@ -79,6 +79,10 @@ func init() {
 }
 
 func runCreate(cmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		log.Fatalf("too many arguments: %v", args)
+	}
+
 	doCreate()
 }
 

--- a/cmd/kube-spawn/destroy.go
+++ b/cmd/kube-spawn/destroy.go
@@ -43,6 +43,10 @@ func init() {
 }
 
 func runDestroy(cmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		log.Fatalf("too many arguments: %v", args)
+	}
+
 	cfg := loadConfig()
 	doDestroy(cfg)
 }

--- a/cmd/kube-spawn/list.go
+++ b/cmd/kube-spawn/list.go
@@ -43,6 +43,10 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		log.Fatalf("too many arguments: %v", args)
+	}
+
 	ksDir := viper.GetString("dir")
 
 	matches, err := filepath.Glob(path.Join(ksDir, "*"))

--- a/cmd/kube-spawn/restart.go
+++ b/cmd/kube-spawn/restart.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"log"
+
 	"github.com/spf13/cobra"
 )
 
@@ -41,6 +43,10 @@ func init() {
 }
 
 func runRestart(cmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		log.Fatalf("too many arguments: %v", args)
+	}
+
 	cfg := loadConfig()
 	doStop(cfg, flagForce)
 	doStart(cfg, flagSkipInit)

--- a/cmd/kube-spawn/start.go
+++ b/cmd/kube-spawn/start.go
@@ -49,6 +49,10 @@ func init() {
 }
 
 func runStart(cmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		log.Fatalf("too many arguments: %v", args)
+	}
+
 	cfg := loadConfig()
 	doStart(cfg, flagSkipInit)
 }

--- a/cmd/kube-spawn/stop.go
+++ b/cmd/kube-spawn/stop.go
@@ -43,6 +43,10 @@ func init() {
 }
 
 func runStop(cmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		log.Fatalf("too many arguments: %v", args)
+	}
+
 	cfg := loadConfig()
 	doStop(cfg, flagForce)
 }

--- a/cmd/kube-spawn/up.go
+++ b/cmd/kube-spawn/up.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"log"
+
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +39,10 @@ func init() {
 }
 
 func runUp(cmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		log.Fatalf("too many arguments: %v", args)
+	}
+
 	doUp()
 }
 


### PR DESCRIPTION
Kube-spawn's commands are meant to run without any arguments, as all the necessary parameters are set via individual options, e.g. `-c` for cluster name, `--kubernetes-version` for the cluster's k8s version, etc. When a user happens to type in unnecessary parameters without an option string, e.g. `kube-spawn destroy mycluster`, then it could result in
unexpected behavior like destroying the `default` cluster, because the cluster name defaults to `default` when there's no '-c' option given.

So we should check for the number of arguments, and fail immediately when any unnecessary argument is given from the command line. Then users can simply react to that by typing a new command with correct options.

Fixes https://github.com/kinvolk/kube-spawn/issues/236