### PR TITLE
cmd/kube-spawn: abort if it's non-root user

### DIFF
--- a/cmd/kube-spawn/create.go
+++ b/cmd/kube-spawn/create.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/sys/unix"
 
 	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
 	"github.com/kinvolk/kube-spawn/pkg/config"
@@ -79,6 +80,10 @@ func init() {
 }
 
 func runCreate(cmd *cobra.Command, args []string) {
+	if unix.Geteuid() != 0 {
+		log.Fatalf("non-root user cannot create clusters. abort.")
+	}
+
 	if len(args) > 0 {
 		log.Fatalf("too many arguments: %v", args)
 	}

--- a/cmd/kube-spawn/destroy.go
+++ b/cmd/kube-spawn/destroy.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 
 	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
 	"github.com/kinvolk/kube-spawn/pkg/config"
@@ -43,6 +44,10 @@ func init() {
 }
 
 func runDestroy(cmd *cobra.Command, args []string) {
+	if unix.Geteuid() != 0 {
+		log.Fatalf("non-root user cannot destroy clusters. abort.")
+	}
+
 	if len(args) > 0 {
 		log.Fatalf("too many arguments: %v", args)
 	}

--- a/cmd/kube-spawn/restart.go
+++ b/cmd/kube-spawn/restart.go
@@ -20,6 +20,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -43,6 +44,10 @@ func init() {
 }
 
 func runRestart(cmd *cobra.Command, args []string) {
+	if unix.Geteuid() != 0 {
+		log.Fatalf("non-root user cannot restart clusters. abort.")
+	}
+
 	if len(args) > 0 {
 		log.Fatalf("too many arguments: %v", args)
 	}

--- a/cmd/kube-spawn/start.go
+++ b/cmd/kube-spawn/start.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 
 	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
 	"github.com/kinvolk/kube-spawn/pkg/config"
@@ -49,6 +50,10 @@ func init() {
 }
 
 func runStart(cmd *cobra.Command, args []string) {
+	if unix.Geteuid() != 0 {
+		log.Fatalf("non-root user cannot start clusters. abort.")
+	}
+
 	if len(args) > 0 {
 		log.Fatalf("too many arguments: %v", args)
 	}

--- a/cmd/kube-spawn/stop.go
+++ b/cmd/kube-spawn/stop.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kinvolk/kube-spawn/pkg/machinetool"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -43,6 +44,10 @@ func init() {
 }
 
 func runStop(cmd *cobra.Command, args []string) {
+	if unix.Geteuid() != 0 {
+		log.Fatalf("non-root user cannot stop clusters. abort.")
+	}
+
 	if len(args) > 0 {
 		log.Fatalf("too many arguments: %v", args)
 	}

--- a/cmd/kube-spawn/up.go
+++ b/cmd/kube-spawn/up.go
@@ -20,6 +20,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -39,6 +40,10 @@ func init() {
 }
 
 func runUp(cmd *cobra.Command, args []string) {
+	if unix.Geteuid() != 0 {
+		log.Fatalf("non-root user cannot create & start clusters. abort.")
+	}
+
 	if len(args) > 0 {
 		log.Fatalf("too many arguments: %v", args)
 	}


### PR DESCRIPTION
Ordinary commands, create, destroy, restart, start, stop, and up, need to run with root privileges. So we need to exit if euid is not 0.

Though we need to exclude the list command, as non-root users are able to read profiles.

Fixes https://github.com/kinvolk/kube-spawn/issues/231