### PR TITLE
[do not merge] pkg/config: split out version checking function into IsVerConstraintOrDev

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -99,7 +99,7 @@ func SetDefaults_Kubernetes(cfg *ClusterConfiguration) error {
 		{Dst: "/usr/bin/socat", Src: path.Join(cacheDir, "socat")},
 	}
 
-	if cfg.DevCluster || utils.CheckVersionConstraint(cfg.KubernetesVersion, ">=1.8.0") {
+	if cfg.IsVerConstraintOrDev(">=1.8.0") {
 		cfg.TokenGroupsOption = "--groups=system:bootstrappers:kubeadm:default-node-token"
 	}
 
@@ -113,7 +113,7 @@ func SetDefaults_RuntimeConfiguration(cfg *ClusterConfiguration) error {
 
 	// NOTE: K8s 1.8 or newer fails to run by default when swap is enabled.
 	// So we should disable the feature with an option "--fail-swap-on=false".
-	if !cfg.DevCluster && utils.CheckVersionConstraint(cfg.KubernetesVersion, "<1.8.0") {
+	if !cfg.IsVerConstraintOrDev(">=1.8.0") {
 		cfg.RuntimeConfiguration.FailSwapOn = true
 	}
 

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
+	"github.com/kinvolk/kube-spawn/pkg/utils"
 	"github.com/kinvolk/kube-spawn/pkg/utils/fs"
 )
 
@@ -79,4 +80,13 @@ func WriteConfigToFile(cfg *ClusterConfiguration) error {
 		return errors.Wrap(err, "unable to encode cluster config")
 	}
 	return fs.CreateFileFromBytes(cfgFilepath, raw)
+}
+
+// returns true if one of the following conditions is true
+//  * DevCluster is true (i.e. "--dev" is given)
+//  * cfg.KubernetesVersion == "latest" (non-semver version string)
+//  * cfg.KubernetesVersion sastifies the given constraint
+func (cfg *ClusterConfiguration) IsVerConstraintOrDev(constraint string) bool {
+	return cfg.DevCluster || cfg.KubernetesVersion == "latest" ||
+		utils.CheckVersionConstraint(cfg.KubernetesVersion, constraint)
 }

--- a/pkg/config/utils_test.go
+++ b/pkg/config/utils_test.go
@@ -1,0 +1,63 @@
+// Copyright 2017 Kinvolk GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+)
+
+func TestIsVerConstraintOrDev(t *testing.T) {
+	var cfg = &ClusterConfiguration{}
+
+	for i, tt := range []struct {
+		devCluster        bool
+		kubernetesVersion string
+		constraint        string
+		expectedResult    bool
+	}{
+		{
+			false,
+			"v1.7.5",
+			">=v1.7.5",
+			true,
+		},
+		{
+			false,
+			"v1.7.5",
+			"<v1.7.5",
+			false,
+		},
+		{
+			true,
+			"v1.8.0",
+			">=v1.7.5",
+			true,
+		},
+		{
+			false,
+			"latest",
+			">=v1.7.5",
+			true,
+		},
+	} {
+		cfg.DevCluster = tt.devCluster
+		cfg.KubernetesVersion = tt.kubernetesVersion
+		outResult := cfg.IsVerConstraintOrDev(tt.constraint)
+
+		if tt.expectedResult != outResult {
+			t.Errorf("IsVerConstraintOrDev %d expected %v got %v", i, tt.expectedResult, outResult)
+		}
+	}
+}

--- a/pkg/nspawntool/kubeadm.go
+++ b/pkg/nspawntool/kubeadm.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kinvolk/kube-spawn/pkg/bootstrap"
 	"github.com/kinvolk/kube-spawn/pkg/config"
 	"github.com/kinvolk/kube-spawn/pkg/machinetool"
-	"github.com/kinvolk/kube-spawn/pkg/utils"
 	"github.com/kinvolk/kube-spawn/pkg/utils/fs"
 	"github.com/pkg/errors"
 )
@@ -98,8 +97,7 @@ func JoinNode(cfg *config.ClusterConfiguration, mNo int) error {
 	// See: https://github.com/kubernetes/kubernetes/pull/49520
 	// It is mandatory since Kubernetes 1.9
 	// See: https://github.com/kubernetes/kubernetes/pull/55468
-	// Test is !<1.8 instead of >=1.8 in order to handle non-semver version 'latest'
-	if !utils.CheckVersionConstraint(cfg.KubernetesVersion, "<1.8") {
+	if cfg.IsVerConstraintOrDev(">=1.8") {
 		joinCmd = append(joinCmd, "--discovery-token-unsafe-skip-ca-verification")
 	}
 


### PR DESCRIPTION
To able to avoid error-prone version checking logic, we need to split it out into `IsVerConstraintOrDev()`. The function returns true if it's dev cluster, or if the kubernetes Version is "latest" (non-semver string), or the kubernetes version sastifies the given  constraint. That way we can simplify call sites as much as possible.

Also add a unit test to cover different cases of input parameters.

Fixes https://github.com/kinvolk/kube-spawn/issues/243