### PR TITLE
kube-spawn: don't double print errors

### DIFF
--- a/cmd/kube-spawn/kube-spawn.go
+++ b/cmd/kube-spawn/kube-spawn.go
@@ -63,7 +63,7 @@ func init() {
 
 func main() {
 	if err := kubespawnCmd.Execute(); err != nil {
-		log.Fatal(err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
If not explicitly disabled, cobra prints errors in `cmd.Execute`, i.e.
no need to log it a second time.

https://github.com/spf13/cobra/blob/ccaecb155a2177302cb56cae929251a256d0f646/command.go#L842-L844