### PR TITLE
[WIP] cnispawn: run container in detached transient unit

### DIFF
--- a/pkg/cnispawn/netns.go
+++ b/pkg/cnispawn/netns.go
@@ -94,3 +94,7 @@ func (c *CniNetns) Set() error {
 func (c *CniNetns) Close() error {
 	return c.netns.Close()
 }
+
+func (c *CniNetns) Path() string {
+	return c.netns.Path()
+}


### PR DESCRIPTION
With that, the container lifetime is not tied to the lifetime of the
slice in which kube-spawn is running.

This commit doesn't add code to shutdown and remove the network
namespace when the cluster is stopped. This is yet to be done.