### PR TITLE
Error out when unknown container runtime is set

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -124,6 +125,8 @@ func SetDefaults_RuntimeConfiguration(cfg *ClusterConfiguration) error {
 		err = SetDefaults_RktRuntime(cfg)
 	case RuntimeCrio:
 		err = SetDefaults_CrioRuntime(cfg)
+	default:
+		return fmt.Errorf("runtime %q not supported", cfg.ContainerRuntime)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
kube-spawn allows users to configure the container runtime with
`--container-runtime` (e.g. `--container-runtime=rkt`) but doesn't
actually make sure the passed value is known/supported and instead
continues with the setup process until it fails at a later stage. Error
out early.