### PR TITLE
[do not merge] kubeadm: use --ignore-preflight-errors=all instead of --skip-preflight-checks

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -102,6 +102,11 @@ func SetDefaults_Kubernetes(cfg *ClusterConfiguration) error {
 	if cfg.DevCluster || utils.CheckVersionConstraint(cfg.KubernetesVersion, ">=1.8.0") {
 		cfg.TokenGroupsOption = "--groups=system:bootstrappers:kubeadm:default-node-token"
 	}
+	if cfg.DevCluster || utils.CheckVersionConstraint(cfg.KubernetesVersion, ">=1.9.0") {
+		cfg.PreflightChecksOption = "--ignore-preflight-errors=all"
+	} else {
+		cfg.PreflightChecksOption = "--skip-preflight-checks"
+	}
 
 	return nil
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -52,8 +52,9 @@ type ClusterConfiguration struct {
 
 	// Token is the token generated on kubeadm init
 	// used to join more workers to the cluster
-	Token             string `toml:"token, omitempty" mapstructure:"token"`
-	TokenGroupsOption string `toml:"token-groups-option, omitempty" mapstructure:"token-groups-option"`
+	Token                 string `toml:"token, omitempty" mapstructure:"token"`
+	TokenGroupsOption     string `toml:"token-groups-option, omitempty" mapstructure:"token-groups-option"`
+	PreflightChecksOption string `toml:"preflight-checks-option, omitempty" mapstructure:"preflight-checks-option"`
 
 	Machines []MachineConfiguration `toml:"machines, omitempty" mapstructure:"machines"`
 }

--- a/pkg/nspawntool/kubeadm.go
+++ b/pkg/nspawntool/kubeadm.go
@@ -25,7 +25,7 @@ func InitializeMaster(cfg *config.ClusterConfiguration) error {
 		shellOpts = fmt.Sprintf(`--setenv=KUBE_HYPERKUBE_IMAGE="10.22.0.1:5000/hyperkube-amd64:%s"`, cfg.HyperkubeTag)
 	}
 	initCmd = append(initCmd, []string{
-		"/usr/bin/kubeadm", "init", "--skip-preflight-checks",
+		"/usr/bin/kubeadm", "init", cfg.PreflightChecksOption,
 		"--config=/etc/kubeadm/kubeadm.yml"}...)
 
 	if err := machinetool.Shell(shellOpts, cfg.Machines[0].Name, initCmd...); err != nil {
@@ -91,7 +91,7 @@ func JoinNode(cfg *config.ClusterConfiguration, mNo int) error {
 		shellOpts = `--setenv=KUBE_HYPERKUBE_IMAGE="10.22.0.1:5000/hyperkube-amd64"`
 	}
 	joinCmd = append(joinCmd, []string{
-		"/usr/bin/kubeadm", "join", "--skip-preflight-checks",
+		"/usr/bin/kubeadm", "join", cfg.PreflightChecksOption,
 		"--token", cfg.Token}...)
 
 	// --discovery-token-unsafe-skip-ca-verification appeared in Kubernetes 1.8


### PR DESCRIPTION
With kubeadm v1.9 or newer, `--skip-preflight-checks` is deprecated. So kubeadm v1.9 prints a warning like "Flag --skip-preflight-checks has been deprecated, it is now equivalent to --ignore-preflight-errors=all" In the future the old option will disappear.

So `--ignore-preflight-errors=all` should be used instead.
