### PR TITLE
pkg/bootstrap: fix a bug when parsing kernel parameters

### DIFF
--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -449,19 +449,29 @@ func isConntrackLoaded() bool {
 }
 
 func isConntrackHashsizeCorrect() bool {
-	hsStr, err := ioutil.ReadFile(ctHashsizeModparam)
+	hsByte, err := ioutil.ReadFile(ctHashsizeModparam)
 	if err != nil {
 		log.Printf("cannot read from %s: %v\n", ctHashsizeModparam, err)
 		return false
 	}
-	hs, _ := strconv.Atoi(string(hsStr))
+	hsStr := strings.TrimSpace(string(hsByte))
+	hs, err := strconv.Atoi(hsStr)
+	if err != nil {
+		log.Printf("parse error on %s: %v\n", hsStr, err)
+		return false
+	}
 
-	ctmaxStr, err := ioutil.ReadFile(ctMaxSysctl)
+	ctmaxByte, err := ioutil.ReadFile(ctMaxSysctl)
 	if err != nil {
 		log.Printf("cannot open %s: %v\n", ctMaxSysctl, err)
 		return false
 	}
-	ctmax, _ := strconv.Atoi(string(ctmaxStr))
+	ctmaxStr := strings.TrimSpace(string(ctmaxByte))
+	ctmax, err := strconv.Atoi(ctmaxStr)
+	if err != nil {
+		log.Printf("parse error on %s: %v\n", ctmaxStr, err)
+		return false
+	}
 
 	if hs < (ctmax / 4) {
 		log.Printf("hashsize(%d) should be greater than nf_conntrack_max/4 (%d).\n", hs, ctmax/4)


### PR DESCRIPTION
`IsConntrackHashsizeCorrect()` is expected to return true, when the value of `/sys/module/nf_conntrack/hashsize` * 4 is less than the value of `/proc/sys/net/nf_conntrack_max`. However so far the string parsing logic has had a bug that the value obtained from the procfs or sysfs is passed without trimming whilespaces. As input string is usually given
such as `16384\n`, with a trailing newline character, `strconv.Atoi()` fails because of the newline. Then both `hs` and `ctmax` become 0, and `IsConntrackHashsizeCorrect()` returns always true. Obviously there will be no chance of adjusting the hashsize correctly as expected.

So we need to apply `strings.Trimspace()` for each input string. Then the newline character will be gone, and `IsConntrackHashsizeCorrect()` will work as expected.

Fixes https://github.com/kinvolk/kube-spawn/issues/255