### PR TITLE
Dockerfile: build kube-spawn based on golang image instead of fedora

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,14 +1,7 @@
-FROM fedora:27
+FROM golang:latest
 
 ENV GOPATH /go
 ENV PATH "/go/bin:${PATH}"
-
-RUN dnf install -y \
-		git \
-		go \
-		make \
-		which \
-	&& dnf clean all
 
 RUN go get -u github.com/golang/dep/...
 


### PR DESCRIPTION
For better build speed, we should use golang docker image instead of fedora, because we don't actually need the whole distro just for building go binaries.

Comparison of build duration, including fetching remote docker images:

* previously with fedora 27:   143.964 sec
* currently with golang latest: 74.608 sec