### PR TITLE
cmd, pkg/bootstrap: support Flatcar Linux as base image

### DIFF
--- a/cmd/kube-spawn/create.go
+++ b/cmd/kube-spawn/create.go
@@ -47,7 +47,6 @@ func init() {
 	kubespawnCmd.AddCommand(createCmd)
 
 	createCmd.Flags().String("container-runtime", "docker", "Runtime to use for the cluster (can be docker or rkt)")
-	createCmd.Flags().String("machinectl-image", "coreos", "Name of the machinectl image to use for the kube-spawn containers")
 	createCmd.Flags().String("kubernetes-version", "v1.9.3", "Kubernetes version to install")
 	createCmd.Flags().String("kubernetes-source-dir", "", "Path to directory with Kubernetes sources")
 	createCmd.Flags().String("hyperkube-image", "", "Kubernetes hyperkube image to use (if unset, upstream k8s is installed)")

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -299,7 +299,7 @@ func (c *Cluster) Start(numberNodes int, cniPluginDir string) error {
 	if numberNodes < 1 {
 		return errors.Errorf("cannot start less than 1 node")
 	}
-	if err := bootstrap.PrepareCoreosImage(); err != nil {
+	if err := bootstrap.PrepareBaseImage(); err != nil {
 		return err
 	}
 
@@ -351,7 +351,7 @@ func (c *Cluster) Start(numberNodes int, cniPluginDir string) error {
 
 			log.Printf("Waiting for machine %s to start up ...", machineName)
 
-			if err := nspawntool.Run("coreos", c.BaseRootfsPath(), path.Join(c.MachineRootfsPath(), machineName), machineName, cniPluginDir); err != nil {
+			if err := nspawntool.Run(bootstrap.BaseImageName, c.BaseRootfsPath(), path.Join(c.MachineRootfsPath(), machineName), machineName, cniPluginDir); err != nil {
 				errorChan <- errors.Wrapf(err, "Failed to start machine %s", machineName)
 				return
 			}

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -32,12 +32,12 @@ import (
 	"github.com/kinvolk/kube-spawn/pkg/utils"
 )
 
-func Run(machinectlImage, lowerRootPath, upperRootPath, machineName, cniPluginDir string) error {
+func Run(baseImageName, lowerRootPath, upperRootPath, machineName, cniPluginDir string) error {
 	if machinectl.IsRunning(machineName) {
 		return errors.Errorf("a machine with name %q is running already", machineName)
 	}
 
-	if err := machinectl.Clone(machinectlImage, machineName); err != nil {
+	if err := machinectl.Clone(baseImageName, machineName); err != nil {
 		return errors.Wrap(err, "error cloning image")
 	}
 


### PR DESCRIPTION
As the base image, we support [Flatcar Linux](https://flatcar-linux.org) images instead of CoreOS Container Linux images.

We replace hard-coded values "coreos" with a proper image name. Let's just remove the `--machinectl-image` option to make it simple.
