### PR TITLE
Fix the check for overlayfs

### DIFF
--- a/pkg/bootstrap/util.go
+++ b/pkg/bootstrap/util.go
@@ -36,6 +36,7 @@ const (
 // It returns error if OverlayFS is not supported.
 //  - taken from https://github.com/rkt/rkt/blob/master/common/common.go
 func PathSupportsOverlay(path string) error {
+	ensureOverlayfs()
 	if !isOverlayfsAvailable() {
 		return fmt.Errorf("overlayfs is not available")
 	}


### PR DESCRIPTION
We check the availability of the overlay kernel module by basically
grepping the contents of `/proc/filesystems` for `overlay`. The check
will fail, if the overlay module wasn't loaded. So let's try to load
the module before checking the `/proc/filesystems` contents.

Normally the proper way for checking the availability of the overlay
kernel module would be to mount a directory with overlayfs
filesystem. At this point, the overlay kernel module would be
automatically loaded and the mount would happen. If the module were
not available, we would get an error. But the problem is that we don't
actually mount anything - it is done by systemd-nspawn. So I guess
that for the sake of a better error reporting and a better cleanup of
a failed state, we don't go that way.