### PR TITLE
pkg/cluster: fix bug when starting cluster with kubeadm >= 1.11

### DIFF
--- a/pkg/cluster/clusterfiles.go
+++ b/pkg/cluster/clusterfiles.go
@@ -75,7 +75,7 @@ mkdir -p /var/lib/weave
 # necessary to prevent docker from being blocked
 systemctl mask systemd-networkd-wait-online.service
 
-kubeadm reset
+kubeadm reset {{.KubeadmResetOptions}}
 systemctl start --no-block kubelet.service
 `
 


### PR DESCRIPTION
When starting a kube-spawn cluster with kubeadm 1.11 or newer, `kube-spawn start` hangs forever during the bootstrap phase. It's because kubeadm 1.11 or newer asks users to type Y or n, while our bootstrap script runs only `kubeadm reset`. It works fine when running with
`kubeadm reset --force`, which breaks kubeadm 1.10 or older, because the lower versions don't support `--force`.

Fix the bug by dealing with kubeadm reset options differently when the kubeadm version is 1.11 or newer.

Fixes https://github.com/kinvolk/kube-spawn/issues/278