### PR TITLE
Re-add `EnlargeStoragePool` invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ It attempts to mimic production setups by making use of OS containers to set up 
 ## Requirements
 
 * `systemd-nspawn` in at least version 233
+* Large enough `/var/lib/machines` partition. kube-spawn will attempt
+  to enlarge the underlying image `/var/lib/machines.raw` on cluster
+  start, but this can only succeed when the image is not in use by
+  another cluster or machine. Not enough disk space is a common source
+  of error. See [doc/troubleshooting](doc/troubleshooting.md#varlibmachines-partition-too-small) for
+  instructions on how to increase the size manually.
 * `qemu-img`
 
 ## Installation

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -3,12 +3,26 @@
 Here are some common issues that we encountered and how we work around or
 fix them. If you discover more, please create an issue or submit a PR.
 
+- [`/var/lib/machines` partition too small](#varlibmachines-partition-too-small)
 - [SELinux](#selinux)
 - [Restarting machines fails without removing machine images](#restarting-machines-fails-without-removing-machine-images)
 - [Running on a version of systemd \< 233](#running-on-a-version-of-systemd--233)
 - [kubeadm init looks like it is hanging](#kubeadm-init-looks-like-it-is-hanging)
 - [Inotify problems with many nodes](#inotify-problems-with-many-nodes)
 - [Issues with ISPs hijacking DNS requests](#issues-with-isps-hijacking-dns-requests)
+
+## `/var/lib/machines` partition too small
+
+Run the following commands to enlarge the storage pool where `POOL_SIZE`
+is the disk image size in bytes:
+
+```
+# umount /var/lib/machines
+# qemu-img resize -f raw /var/lib/machines.raw POOL_SIZE
+# mount -t btrfs -o loop /var/lib/machines.raw /var/lib/machines
+# btrfs filesystem resize max /var/lib/machines
+# btrfs quota disable /var/lib/machines
+```
 
 ## SELinux
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -307,6 +307,14 @@ func (c *Cluster) Start(numberNodes int, cniPluginDir string) error {
 		return err
 	}
 
+	poolSize, err := bootstrap.GetPoolSize(bootstrap.BaseImageName, numberNodes)
+	if err != nil {
+		return err
+	}
+	if err := bootstrap.EnlargeStoragePool(poolSize); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
While working on 924bb3b41a4126a4c89e4be8779ac014f0d41151 I did not
re-add the `EnlargeStoragePool` invocation and first time users
encountered disk space issues more often again ever since.

Also, add a note to the README and troubleshooting document to tell
users what to do.

Partly covers #281