### PR TITLE
pkg/bootstrap: fix a race between machinectl image-status and umount

### DIFF
--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/kinvolk/kube-spawn/pkg/machinectl"
+	"github.com/kinvolk/kube-spawn/pkg/utils"
 	"github.com/pkg/errors"
 )
 
@@ -102,11 +103,19 @@ func EnlargeStoragePool(poolSize int64) error {
 	//  # btrfs quota disable /var/lib/machines
 	if err := checkMountpoint(machinesDir); err == nil {
 		// It means machinesDir is mountpoint, so do unmount
-		if err := syscall.Unmount(machinesDir, 0); err != nil {
-			// if it's already unmounted, umount(2) returns EINVAL, then continue
-			if !os.IsNotExist(err) && err != syscall.EINVAL {
-				return err
+		// Note that "umount /var/lib/machines" could fail in case "machinectl image-status"
+		// has run once at least. So if the unmount fails, we should retry to unmount
+		// up to 3 seconds.
+		if err := utils.WaitForState(func() error {
+			if err := syscall.Unmount(machinesDir, 0); err != nil {
+				// if it's already unmounted, umount(2) returns EINVAL, then continue
+				if !os.IsNotExist(err) && err != syscall.EINVAL {
+					return err
+				}
 			}
+			return nil
+		}); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/utils/wait.go
+++ b/pkg/utils/wait.go
@@ -1,0 +1,37 @@
+//
+// Copyright 2018 Kinvolk GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"time"
+)
+
+func WaitForState(stateCheckFunc func() error) error {
+	timeout := 3 * time.Second
+	alarm := time.After(timeout)
+	ticker := time.Tick(500 * time.Millisecond)
+	for {
+		select {
+		case <-alarm:
+			return fmt.Errorf("failed to reach expected state within %v", timeout)
+		case <-ticker:
+			if err := stateCheckFunc(); err == nil {
+				return nil
+			}
+		}
+	}
+}


### PR DESCRIPTION
There has been an issue of `umount /var/lib/machines` failing with -EBUSY. It happens only when a command `machinectl image-status` runs once at least. So we need to make a retry loop to attempt to umount, up to 3 seconds, to make it work correctly.