### PR TITLE
Add support for flannel and calico.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ container-runtime: rkt
 rktlet-binary-path: /home/user/code/go/src/github.com/kubernetes-incubator/rktlet/bin/rktlet
 ```
 
+## CNI models
+
+kube-spawn supports weave, flannel, calico. It defaults to weave.
+
+To configure with flannel:
+```
+kube-spawn create --pod-network-cidr 10.244.0.0/16 --cni-plugin flannel --kubernetes-version=v1.10.5
+kube-spawn start --cni-plugin flannel --nodes 5
+```
+
+To configure with calico:
+```
+kube-spawn create --pod-network-cidr 192.168.0.0/16 --cni-plugin calico --kubernetes-version=v1.10.5
+kube-spawn start --cni-plugin calico --nodes 5
+```
+
 ## Accessing kube-spawn nodes
 
 All nodes can be seen with `machinectl list`. `machinectl shell` can be

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ container-runtime: rkt
 rktlet-binary-path: /home/user/code/go/src/github.com/kubernetes-incubator/rktlet/bin/rktlet
 ```
 
-## CNI models
+## CNI plugins
 
 kube-spawn supports weave, flannel, calico. It defaults to weave.
 

--- a/cmd/kube-spawn/create.go
+++ b/cmd/kube-spawn/create.go
@@ -51,6 +51,9 @@ func init() {
 	createCmd.Flags().String("kubernetes-source-dir", "", "Path to directory with Kubernetes sources")
 	createCmd.Flags().String("hyperkube-image", "", "Kubernetes hyperkube image to use (if unset, upstream k8s is installed)")
 	createCmd.Flags().String("cni-plugin-dir", "/opt/cni/bin", "Path to directory with CNI plugins")
+	createCmd.Flags().String("cni-plugin", "weave", "CNI plugin to use (weave, flannel, calico)")
+	createCmd.Flags().String("cluster-cidr", "", "Cluster CIDR to use")
+	createCmd.Flags().String("pod-network-cidr", "", "Pod Network CIDR to use")
 	createCmd.Flags().String("rkt-binary-path", "/usr/local/bin/rkt", "Path to rkt binary")
 	createCmd.Flags().String("rkt-stage1-image-path", "/usr/local/bin/stage1-coreos.aci", "Path to rkt stage1-coreos.aci image")
 	createCmd.Flags().String("rktlet-binary-path", "/usr/local/bin/rktlet", "Path to rktlet binary")
@@ -88,7 +91,10 @@ func doCreate() {
 		KubernetesVersion:   viper.GetString("kubernetes-version"),
 		KubernetesSourceDir: viper.GetString("kubernetes-source-dir"),
 		CNIPluginDir:        viper.GetString("cni-plugin-dir"),
+		CNIPlugin:           viper.GetString("cni-plugin"),
 		ContainerRuntime:    viper.GetString("container-runtime"),
+		ClusterCIDR:         viper.GetString("cluster-cidr"),
+		PodNetworkCIDR:      viper.GetString("pod-network-cidr"),
 		RktBinaryPath:       viper.GetString("rkt-binary-path"),
 		RktStage1ImagePath:  viper.GetString("rkt-stage1-image-path"),
 		RktletBinaryPath:    viper.GetString("rktlet-binary-path"),

--- a/cmd/kube-spawn/start.go
+++ b/cmd/kube-spawn/start.go
@@ -39,6 +39,7 @@ func init() {
 
 	startCmd.Flags().IntP("nodes", "n", 3, "Number of nodes to start")
 	startCmd.Flags().String("cni-plugin-dir", "/opt/cni/bin", "Path to directory with CNI plugins")
+	startCmd.Flags().String("cni-plugin", "weave", "CNI plugin (weave, flannel, calico)")
 }
 
 func runStart(cmd *cobra.Command, args []string) {
@@ -55,13 +56,14 @@ func doStart() {
 	clusterName := viper.GetString("cluster-name")
 	numberNodes := viper.GetInt("nodes")
 	cniPluginDir := viper.GetString("cni-plugin-dir")
+	cniPlugin := viper.GetString("cni-plugin")
 
 	kluster, err := cluster.New(path.Join(kubespawnDir, "clusters", clusterName), clusterName)
 	if err != nil {
 		log.Fatalf("Failed to create cluster object: %v", err)
 	}
 
-	if err := kluster.Start(numberNodes, cniPluginDir); err != nil {
+	if err := kluster.Start(numberNodes, cniPluginDir, cniPlugin); err != nil {
 		log.Fatalf("Failed to start cluster: %v", err)
 	}
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -29,7 +29,10 @@ import (
 
 type ClusterSettings struct {
 	CNIPluginDir          string
+	CNIPlugin             string
 	ContainerRuntime      string
+	ClusterCIDR           string
+	PodNetworkCIDR        string
 	HyperkubeImage        string
 	KubeadmResetOptions   string
 	KubernetesSourceDir   string
@@ -63,6 +66,9 @@ func randString(n int) string {
 const (
 	validNameRegexpStr = "^[a-zA-Z0-9-]{1,50}$"
 	weaveNet           = "https://github.com/weaveworks/weave/releases/download/v2.0.5/weave-daemonset-k8s-1.7.yaml"
+	flannelNet         = "https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml"
+	calicoRBAC         = "https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml"
+	calicoNet          = "https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml"
 
 	// Avoid token passing between master and worker nodes by using
 	// a hard-coded token
@@ -191,9 +197,15 @@ func (c *Cluster) Create(clusterSettings *ClusterSettings, clusterCache *cache.C
 
 	socatPath := path.Join(clusterCache.Dir(), "socat")
 	copyItems = append(copyItems, copyItem{dst: "/usr/bin/socat", src: socatPath})
-
-	copyItems = append(copyItems, copyItem{dst: "/opt/cni/bin/bridge", src: path.Join(clusterSettings.CNIPluginDir, "bridge")})
-	copyItems = append(copyItems, copyItem{dst: "/opt/cni/bin/loopback", src: path.Join(clusterSettings.CNIPluginDir, "loopback")})
+	files, err := ioutil.ReadDir(clusterSettings.CNIPluginDir)
+	if err != nil {
+		return errors.Errorf("no CNI plugins in %q", clusterSettings.CNIPluginDir)
+	}
+	for _, file := range files {
+		var dst string = path.Join("opt/cni/bin", file.Name())
+		var src string = path.Join(clusterSettings.CNIPluginDir, file.Name())
+		copyItems = append(copyItems, copyItem{dst: dst, src: src})
+	}
 
 	if clusterSettings.ContainerRuntime == "rkt" {
 		copyItems = append(copyItems, copyItem{dst: "/usr/bin/rkt", src: clusterSettings.RktBinaryPath})
@@ -260,8 +272,14 @@ func prepareBaseRootfs(rootfsDir string, clusterSettings *ClusterSettings) error
 	if err := fs.CreateFileFromString(path.Join(rootfsDir, "/etc/resolv.conf"), "nameserver 8.8.8.8"); err != nil {
 		return err
 	}
+
 	if clusterSettings.ContainerRuntime == "rkt" {
-		if err := fs.CreateFileFromString(path.Join(rootfsDir, "/etc/systemd/system/rktlet.service"), RktletSystemdUnit); err != nil {
+		buf, err := ExecuteTemplate(RktletSystemdUnitTmpl, clusterSettings)
+		if err != nil {
+			return err
+		}
+		if err := fs.CreateFileFromReader(path.Join(rootfsDir, "/etc/systemd/system/rktlet.service"),
+			&buf); err != nil {
 			return err
 		}
 	}
@@ -309,7 +327,7 @@ func prepareBaseRootfs(rootfsDir string, clusterSettings *ClusterSettings) error
 	return nil
 }
 
-func (c *Cluster) Start(numberNodes int, cniPluginDir string) error {
+func (c *Cluster) Start(numberNodes int, cniPluginDir string, cniPlugin string) error {
 	if numberNodes < 1 {
 		return errors.Errorf("cannot start less than 1 node")
 	}
@@ -413,7 +431,7 @@ func (c *Cluster) Start(numberNodes int, cniPluginDir string) error {
 	if err := kubeadmInit(kubeadmVersion, masterMachine.Name, cliWriter); err != nil {
 		return errors.Wrapf(err, "failed to kubeadm init %q", masterMachine.Name)
 	}
-	if err := applyNetworkPlugin(masterMachine.Name, cliWriter); err != nil {
+	if err := applyNetworkPlugin(masterMachine.Name, cniPlugin, cliWriter); err != nil {
 		return err
 	}
 
@@ -666,9 +684,25 @@ func getKubeadmResetOptions(kubeadmVersionStr string) (string, error) {
 	return kubeadmResetOptions, nil
 }
 
-func applyNetworkPlugin(machineName string, outWriter io.Writer) error {
-	_, err := machinectl.RunCommand(outWriter, nil, "", "shell", machineName, "/usr/bin/kubectl", "apply", "-f", weaveNet)
-	return err
+func applyNetworkPlugin(machineName string, cniPlugin string, outWriter io.Writer) error {
+	switch cniPlugin {
+	case "weave":
+		_, err := machinectl.RunCommand(outWriter, nil, "", "shell", machineName, "/usr/bin/kubectl", "apply", "-f", weaveNet)
+		return err
+	case "flannel":
+		_, err := machinectl.RunCommand(outWriter, nil, "", "shell", machineName, "/usr/bin/kubectl", "apply", "-f", flannelNet)
+		return err
+	case "calico":
+		_, err1 := machinectl.RunCommand(outWriter, nil, "", "shell", machineName, "/usr/bin/kubectl", "apply", "-f", calicoRBAC)
+		_, err2 := machinectl.RunCommand(outWriter, nil, "", "shell", machineName, "/usr/bin/kubectl", "apply", "-f", calicoNet)
+		if err1 != nil {
+			return err1
+		}
+		return err2
+	default:
+		return errors.Errorf("Incorrect cni plugin %q", cniPlugin)
+	}
+	return nil
 }
 
 type kubeadmVersionType struct {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -76,7 +76,7 @@ const (
 )
 
 var cniFiles = map[string][]string{
-	"base":    {"bridge", "cnitool", "dhcp", "host-device", "host-local", "ipvlan", "loopback", "macvlan", "noop", "portmap", "ptp", "sample", "tuning", "vlan"},
+	"base":    {"bridge", "dhcp", "host-device", "host-local", "ipvlan", "loopback", "macvlan", "portmap", "ptp", "sample", "tuning", "vlan"},
 	"flannel": {"flannel"},
 	"calico":  {"calico", "calico-ipam"},
 	"weave":   {},

--- a/pkg/cluster/clusterfiles.go
+++ b/pkg/cluster/clusterfiles.go
@@ -31,12 +31,12 @@ const DockerSystemdDropin = `[Service]
 Environment="DOCKER_OPTS=--exec-opt native.cgroupdriver=cgroupfs"
 `
 
-const RktletSystemdUnit = `[Unit]
+const RktletSystemdUnitTmpl = `[Unit]
 Description=rktlet: The rkt implementation of a Kubernetes Container Runtime
 Documentation=https://github.com/kubernetes-incubator/rktlet/tree/master/docs
 
 [Service]
-ExecStart=/usr/bin/rktlet --net=weave
+ExecStart=/usr/bin/rktlet --net={{ .CNIPlugin }}
 Restart=always
 StartLimitInterval=0
 RestartSec=10
@@ -112,6 +112,15 @@ apiServerExtraArgs:
 controllerManagerExtraArgs:
 kubernetesVersion: {{.KubernetesVersion}}
 schedulerExtraArgs:
+{{if .ClusterCIDR -}}
+kubeProxy:
+  config:
+    clusterCIDR: {{.ClusterCIDR}}
+{{- end }}
+{{if .PodNetworkCIDR -}}
+networking:
+  podSubnet: {{.PodNetworkCIDR}}
+{{- end }}
 {{if .HyperkubeImage -}}
 unifiedControlPlaneImage: {{.HyperkubeImage}}
 {{- end }}


### PR DESCRIPTION
Default remains weave. User can now set --cni-model [weave|flannel|calico]
on create. For flannel and calico one must also set pod-network-cidr
(as per https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/).

Add ability to set cluster-cidr.