### PR TITLE
pkg/cluster: change API to v1alpha2 for kubeadm >= 1.11

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -34,6 +34,7 @@ type ClusterSettings struct {
 	ClusterCIDR           string
 	PodNetworkCIDR        string
 	HyperkubeImage        string
+	KubeadmApiVersion     string
 	KubeadmResetOptions   string
 	KubernetesSourceDir   string
 	KubernetesVersion     string
@@ -302,6 +303,13 @@ func prepareBaseRootfs(rootfsDir string, clusterSettings *ClusterSettings) error
 	if err != nil {
 		return err
 	}
+
+	apiVersion, err := getKubeadmApiVersion(kubeadmVersion)
+	if err != nil {
+		return err
+	}
+	clusterSettings.KubeadmApiVersion = apiVersion
+
 	opts, err := getKubeadmResetOptions(kubeadmVersion)
 	if err != nil {
 		return err
@@ -698,6 +706,24 @@ func getKubeadmResetOptions(kubeadmVersionStr string) (string, error) {
 		kubeadmResetOptions = "--force"
 	}
 	return kubeadmResetOptions, nil
+}
+
+func getKubeadmApiVersion(kubeadmVersionStr string) (string, error) {
+	kubeadmApiVersion := ""
+	kubeadmVersion, err := semver.NewVersion(kubeadmVersionStr)
+	if err != nil {
+		return "", err
+	}
+	isLargerEqual111, err := semver.NewConstraint(">= 1.11")
+	if err != nil {
+		return "", err
+	}
+	if isLargerEqual111.Check(kubeadmVersion) {
+		kubeadmApiVersion = "v1alpha2"
+	} else {
+		kubeadmApiVersion = "v1alpha1"
+	}
+	return kubeadmApiVersion, nil
 }
 
 func applyNetworkPlugin(machineName string, cniPlugin string, outWriter io.Writer) error {

--- a/pkg/cluster/clusterfiles.go
+++ b/pkg/cluster/clusterfiles.go
@@ -105,7 +105,7 @@ Environment="KUBELET_EXTRA_ARGS=\
 --authentication-token-webhook"
 `
 
-const KubeadmConfigTmpl = `apiVersion: kubeadm.k8s.io/v1alpha1
+const KubeadmConfigTmpl = `apiVersion: kubeadm.k8s.io/{{.KubeadmApiVersion}}
 authorizationMode: AlwaysAllow
 apiServerExtraArgs:
   insecure-port: "8080"


### PR DESCRIPTION
Since k8s v1.11, API version of kubeadm has changed to `v1alpha2`, and `v1alpha1` is deprecated. So it's recommended to use `v1alpha2` for kubeadm >= 1.11, and `v1alpha1` will be completely removed in the upcoming release 1.12.

We need to introduce a new option for the API version, to conditionally deal with it.

Fixes https://github.com/kinvolk/kube-spawn/issues/280