### PR TITLE
scripts: fix vagrant setup script to make it up-to-date

### DIFF
--- a/doc/distro.md
+++ b/doc/distro.md
@@ -9,7 +9,7 @@ following things are done on your system, no matter which distro you run on.
 * set SELinux mode to either `Permissive` or `Disabled`, e.g.: `sudo setenforce 0`
 * set env variables correctly
   * set `GOPATH` correctly, e.g. `export GOPATH=$HOME/go`
-  * set `KUBECONFIG`: `export KUBECONFIG=/var/lib/kube-spawn/default/kubeconfig`
+  * set `KUBECONFIG`: `export KUBECONFIG=/var/lib/kube-spawn/clusters/default/admin.kubeconfig`
 
 ### Fedora
 

--- a/vendor/github.com/docker/docker/hack/make/.build-deb/docker-engine.docker.default
+++ b/vendor/github.com/docker/docker/hack/make/.build-deb/docker-engine.docker.default
@@ -1,1 +1,0 @@
-../../../contrib/init/sysvinit-debian/docker.default

--- a/vendor/github.com/docker/docker/hack/make/.build-deb/docker-engine.docker.init
+++ b/vendor/github.com/docker/docker/hack/make/.build-deb/docker-engine.docker.init
@@ -1,1 +1,0 @@
-../../../contrib/init/sysvinit-debian/docker

--- a/vendor/github.com/docker/docker/hack/make/.build-deb/docker-engine.docker.upstart
+++ b/vendor/github.com/docker/docker/hack/make/.build-deb/docker-engine.docker.upstart
@@ -1,1 +1,0 @@
-../../../contrib/init/upstart/docker.conf

--- a/vendor/github.com/docker/docker/hack/make/.build-deb/docker-engine.udev
+++ b/vendor/github.com/docker/docker/hack/make/.build-deb/docker-engine.udev
@@ -1,1 +1,0 @@
-../../../contrib/udev/80-docker.rules

--- a/vendor/github.com/docker/docker/project/CONTRIBUTORS.md
+++ b/vendor/github.com/docker/docker/project/CONTRIBUTORS.md
@@ -1,1 +1,0 @@
-../CONTRIBUTING.md


### PR DESCRIPTION
* Move the `--nodes` option to `start` command, as `create` does not  have the option any more.
* Use `--cni-plugin-dir` instead of an env variable
* Fix `$KUBECONFIG` to `/var/lib/kube-spawn/clusters/default/admin.kubeconfig`
* Replace coreos with flatcar

Fixes https://github.com/kinvolk/kube-spawn/issues/289