### PR TITLE
[WIP] pkg/cluster: use kubelet.conf instead of cmdline parameters

### DIFF
--- a/pkg/cluster/clusterfiles.go
+++ b/pkg/cluster/clusterfiles.go
@@ -105,7 +105,23 @@ Environment="KUBELET_EXTRA_ARGS=\
 --authentication-token-webhook"
 `
 
-const KubeadmConfigTmpl = `apiVersion: kubeadm.k8s.io/{{.KubeadmApiVersion}}
+const KubeletConfigTmpl = `kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  webhook:
+    enabled: true
+cgroupDriver: {{ if .UseLegacyCgroupDriver }}cgroupfs{{else}}systemd{{end}}
+cgroupsPerQOS: false
+enforceNodeAllocatable:
+evictionHard:
+failSwapOn: false
+{{ if ne .ContainerRuntime "docker" -}}
+runtimeRequestTimeout: 15m
+NodeRegistration:
+  CRISocket: {{.RuntimeEndpoint}}
+{{- end}}
+`
+const KubeadmConfigTmpl = `apiVersion: kubeadm.k8s.io/v1alpha1
 authorizationMode: AlwaysAllow
 apiServerExtraArgs:
   insecure-port: "8080"


### PR DESCRIPTION
WIP

Since K8s v1.11, kubelet options should be defined in `kubelet.conf` instead of cmdline parameters. Still cmdline parameters are not deprecated yet, so it's not an urgent issue for now. Though we need to test this PR for possible scenarios.

Fixes https://github.com/kinvolk/kube-spawn/issues/286