### PR TITLE
Document how to use kube-spawn on openSUSE Kubic

### DIFF
--- a/doc/distro.md
+++ b/doc/distro.md
@@ -53,3 +53,23 @@ systemctl is-enabled systemd-resolved >& /dev/null && sudo systemctl disable sys
 
 Normally it should be similar to Ubuntu.
 
+### openSUSE Kubic
+
+All versions of openSUSE Kubic should work. 
+
+#### install required packages
+
+```
+transactional-update pkg install kubectl systemd-container cni-plugins
+systemctl reboot
+```
+
+#### CNI plugins
+
+openSUSE has a cni-plugin RPM. If this should be used, CNI_PATH
+has to be set:
+
+```
+export CNI_PATH=/usr/lib/cni
+```
+


### PR DESCRIPTION
kube-spawn works fine on openSUSE Kubic, document how to install it.