### PR TITLE
Make master/worker be numbered rather than random-string for name.

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -391,9 +391,9 @@ func (c *Cluster) Start(numberNodes int, cniPluginDir string, cniPlugin string) 
 
 			var machineNameSuffix string
 			if nodeNumber == 0 {
-				machineNameSuffix = fmt.Sprintf("master-%s", randString(6))
+				machineNameSuffix = fmt.Sprintf("master-%d", nodeNumber)
 			} else {
-				machineNameSuffix = fmt.Sprintf("worker-%s", randString(6))
+				machineNameSuffix = fmt.Sprintf("worker-%d", nodeNumber)
 			}
 			machineName := fmt.Sprintf("kube-spawn-%s-%s", c.name, machineNameSuffix)
 


### PR DESCRIPTION
Rationale: using NodePort, its simpler to remember `kube-spawn-cluster-worker-1` than to do a machinectl and find the machine name which was used. The former is invariant across invocations.