### PR TITLE
travis, Vagrantfile: upgrade Go, Fedora, Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ services:
 install: true
 
 go:
-  - 1.9.x
+  - 1.11.x
 
 before_script:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.9.1
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin latest
 
 script:
   - echo run lint

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ ENV["TERM"] = "xterm-256color"
 ENV["LC_ALL"] = "en_US.UTF-8"
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "fedora/26-cloud-base" # defaults to fedora
+  config.vm.box = "fedora/28-cloud-base" # defaults to fedora
 
   # common parts
   if Vagrant.has_plugin?("vagrant-vbguest")
@@ -22,9 +22,9 @@ Vagrant.configure("2") do |config|
     vb.customize ["modifyvm", :id, "--cpus", "2"]
   end
 
-  # Fedora 26
+  # Fedora 28
   config.vm.define "fedora", primary: true do |fedora|
-    config.vm.provision "shell", inline: "dnf install -y btrfs-progs git go iptables libselinux-utils polkit qemu-img rinetd systemd-container"
+    config.vm.provision "shell", inline: "dnf install -y btrfs-progs git go iptables libselinux-utils make polkit qemu-img rinetd systemd-container"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
@@ -45,10 +45,10 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  # Ubuntu 17.10 (Artful)
+  # Ubuntu 18.04 (Artful)
   config.vm.define "ubuntu", autostart: false do |ubuntu|
-    config.vm.box = "generic/ubuntu1710"
-    config.vm.provision "shell", inline: "apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y btrfs-progs git golang iptables policykit-1 qemu-utils rinetd selinux-utils systemd-container"
+    config.vm.box = "generic/ubuntu1804"
+    config.vm.provision "shell", inline: "apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y btrfs-progs git golang iptables make policykit-1 qemu-utils rinetd selinux-utils systemd-container"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",
@@ -69,7 +69,7 @@ Vagrant.configure("2") do |config|
   # Debian testing
   config.vm.define "debian", autostart: false do |debian|
     config.vm.box = "debian/testing64"
-    config.vm.provision "shell", inline: "echo deb http://httpredir.debian.org/debian unstable main >> /etc/apt/sources.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y btrfs-progs git golang iptables policykit-1 qemu-utils rinetd selinux-utils systemd-container"
+    config.vm.provision "shell", inline: "echo deb http://httpredir.debian.org/debian unstable main >> /etc/apt/sources.list; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y btrfs-progs git golang iptables make policykit-1 qemu-utils rinetd selinux-utils systemd-container"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/kinvolk/kube-spawn",


### PR DESCRIPTION
Upgrade go from 1.9 to 1.11.
(Note, golangci needs to be `latest`, as there's no 1.11 yet.)

Upgrade Fedora from 26 to 28, Ubuntu from 17.10 to 18.04.

Install make before building kube-spawn.
