### PR TITLE
Put /var/lib/kubelet onto host as bind-mount rather than in container.

### DIFF
--- a/pkg/cluster/clusterfiles.go
+++ b/pkg/cluster/clusterfiles.go
@@ -75,7 +75,7 @@ mkdir -p /var/lib/weave
 # necessary to prevent docker from being blocked
 systemctl mask systemd-networkd-wait-online.service
 
-kubeadm reset {{.KubeadmResetOptions}}
+[ -f /etc/kubernetes/kubelet.conf ] && kubeadm reset {{.KubeadmResetOptions}}
 systemctl start --no-block kubelet.service
 `
 

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -66,6 +66,7 @@ func Run(baseImageName, lowerRootPath, upperRootPath, machineName, cniPluginDir 
 	bindmountDirs := []string{
 		"/var/lib/docker",
 		"/var/lib/rktlet",
+		"/var/lib/kubelet",
 	}
 	for _, d := range bindmountDirs {
 		if err := os.MkdirAll(path.Join(upperRootPath, d), 0755); err != nil {


### PR DESCRIPTION
The /var/lib/kubelet directory is used to store the emptyDir
volumes of the various Pods. The worker container has < 1GB of
space free, insufficient. Change /var/lib/kublet to be
a bind-mount of the host.

Kubeadm reset removes the /var/lib/kubelet directory (which
is our bind-mount). However, kubeadm reset is not required
since the image starts up fresh, so remove it.

Resolves https://github.com/kinvolk/kube-spawn/issues/309