### PR TITLE
pkg/bootstrap: verify hash of each k8s binary file

### DIFF
--- a/pkg/bootstrap/download.go
+++ b/pkg/bootstrap/download.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/kinvolk/kube-spawn/pkg/utils"
 	"github.com/kinvolk/kube-spawn/pkg/utils/fs"
 	"github.com/pkg/errors"
 )
@@ -16,16 +17,21 @@ const (
 	k8sURL         string = "https://dl.k8s.io/$VERSION/bin/linux/amd64/"
 	k8sGithubURL   string = "https://raw.githubusercontent.com/kubernetes/kubernetes/$VERSION/build/rpms/"
 	staticSocatUrl string = "https://raw.githubusercontent.com/andrew-d/static-binaries/530df977dd38ba3b4197878b34466d49fce69d8e/binaries/linux/x86_64/socat"
+
+	sha1Suffix string = ".sha1"
 )
 
 var (
 	// note: we are downloading these in parallel (limit number or improve DownloadK8sBins func)
-	k8sfiles = []string{
-		k8sURL + "kubelet",
-		k8sURL + "kubeadm",
-		k8sURL + "kubectl",
-		k8sGithubURL + "kubelet.service",
-		k8sGithubURL + "10-kubeadm.conf",
+	//
+	// key: full URL for a file to be downloaded.
+	// value: whether it has to be verified with checksum or not
+	k8sBinaryFiles = map[string]bool{
+		k8sURL + "kubelet":               true,
+		k8sURL + "kubeadm":               true,
+		k8sURL + "kubectl":               true,
+		k8sGithubURL + "kubelet.service": false,
+		k8sGithubURL + "10-kubeadm.conf": false,
 	}
 )
 
@@ -54,10 +60,10 @@ func DownloadKubernetesBinaries(k8sVersion, targetDir string) error {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(len(k8sfiles))
-	for _, url := range k8sfiles {
+	wg.Add(len(k8sBinaryFiles))
+	for url, verifyHash := range k8sBinaryFiles {
 		// replace placeholder $VERSION with actual version parameter
-		go func(url string) {
+		go func(url string, verifyHash bool) {
 			defer wg.Done()
 			url = strings.Replace(url, "$VERSION", k8sVersion, 1)
 			inCachePath := path.Join(versionPath, path.Base(url))
@@ -70,10 +76,25 @@ func DownloadKubernetesBinaries(k8sVersion, targetDir string) error {
 					err = errors.Wrapf(err, "error downloading %s", url)
 					return
 				}
+
+				if verifyHash {
+					sha1URL := url + sha1Suffix
+					sha1CachePath := inCachePath + sha1Suffix
+					if err = Download(sha1URL, sha1CachePath); err != nil {
+						err = errors.Wrapf(err, "error downloading %s", sha1URL)
+						return
+					}
+
+					if err = utils.VerifySha1(inCachePath, sha1CachePath); err != nil {
+						err = errors.Wrapf(err, "error verifying checksum of %s", sha1URL)
+						return
+					}
+				}
 			}
-		}(url)
+		}(url, verifyHash)
 	}
 	wg.Wait()
+
 	return err
 }
 

--- a/pkg/utils/hash.go
+++ b/pkg/utils/hash.go
@@ -1,0 +1,51 @@
+//
+// Copyright 2018 Kinvolk GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package utils
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"io/ioutil"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func VerifySha1(binFilePath, checksumPath string) error {
+	outB, err := ioutil.ReadFile(binFilePath)
+	if err != nil {
+		return errors.Wrapf(err, "error reading file %s", binFilePath)
+	}
+
+	outC, err := ioutil.ReadFile(checksumPath)
+	if err != nil {
+		return errors.Wrapf(err, "error reading file %s", checksumPath)
+	}
+
+	hasher := sha1.New()
+	if _, err := hasher.Write(outB); err != nil {
+		return errors.Wrapf(err, "error reading for hash from %s", binFilePath)
+	}
+
+	hashSha := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+
+	if strings.TrimSpace(hashSha) != strings.TrimSpace(string(outC)) {
+		return errors.Wrapf(err, "error verifying checksum for file %s", binFilePath)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Downloaded k8s binary files, e.g. `kubectl`, sometimes can be corrupted, due to many reasons, like intermittent network errors. The thing is, in this case kube-spawn simply continues to start clusters with the broken files, and actually tries to run those. It obviously fails, but the failures are not directly visible to users, so users need to get into one of the containers to debug the issues. For most users it's quite hard.

To fix that, we should verify if each downloaded Kubernetes binary file is valid, with help of the given sha1 hash file, i.e. `filename+".sha1"`. (Unfortunately on dl.k8s.io, there's no other hash file available, no sha256 at all) If the hash is not correct, simply error out to inform users that something is wrong with the files.

For example, it does the same job as below:
```
$ curl -sSLO https://dl.k8s.io/v1.11.0/bin/linux/amd64/kubectl
$ curl -sSLO https://dl.k8s.io/v1.11.0/bin/linux/amd64/kubectl.sha1
$ [ "$(sha1sum kubectl | cut -d\  -f1)" = "$(cat kubectl.sha1)" ] && echo "pass" || echo "fail"
pass
```