### PR TITLE
pkg/cluster: set COLUMNS to a bigger value to get systemd machine names

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -52,6 +52,12 @@ type Cluster struct {
 
 func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
+
+	// This is needed to avoid ellipsis at the end of machine name, when running
+	// `machinectl list` or `machinectl list-images`. Without setting COLUMNS to a
+	// high value, machinectl prints out a shortened machine name with an ellipsis
+	// at the end, so kube-spawn fails to start or stop the cluster.
+	_ = os.Setenv("COLUMNS", "200")
 }
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"


### PR DESCRIPTION
Since systemd v239, `machinectl {list,list-images}` started to shorten each machine name with ellipsis("…"), when the terminal is narrow and unicode is being used.

So before v239, `machinectl list` showed like this:

```
kube-spawn-default-master-4nr5ar container systemd-nspawn - - 10.22.0.206...
```

But since v239, it's like that:

```
kube-spawn-default-master-4n… container systemd-nspawn - - 10.22.0.206…
```

As a result, each machine name returned by `List()` and `ListImages()` does not match with an expected name. Both `kube-spawn start` and `kube-spawn stop` do not work, when unicode is being used.

There does not seem to be a way to avoid the shorted name by using an option. Adding `--full` does not solve anything.

To fix that, we need to set an environment variable `COLUMNS` to a fairly big value, 200.