### PR TITLE
pkg/cluster: add kind field in the kubeadm config option

### DIFF
--- a/pkg/cluster/clusterfiles.go
+++ b/pkg/cluster/clusterfiles.go
@@ -106,6 +106,7 @@ Environment="KUBELET_EXTRA_ARGS=\
 `
 
 const KubeadmConfigTmpl = `apiVersion: kubeadm.k8s.io/{{.KubeadmApiVersion}}
+kind: MasterConfiguration
 authorizationMode: AlwaysAllow
 apiServerExtraArgs:
   insecure-port: "8080"


### PR DESCRIPTION
Starting from kubeadm v1.12.0, both `kind` and `apiVersion` are necessary in the kubeadm config file when initializing the cluster. If `kind` is missing, `kubeadm init` simply fails like this:

```
master-ajk8ix invalid configuration: kind and apiVersion is mandatory information that needs to be specified in all YAML documents
Failed to start cluster ...
```