### PR TITLE
cmd, pkg: allow for specifying an arbitrary flatcar channel

### DIFF
--- a/cmd/kube-spawn/start.go
+++ b/cmd/kube-spawn/start.go
@@ -40,6 +40,7 @@ func init() {
 	startCmd.Flags().IntP("nodes", "n", 3, "Number of nodes to start")
 	startCmd.Flags().String("cni-plugin-dir", "/opt/cni/bin", "Path to directory with CNI plugins")
 	startCmd.Flags().String("cni-plugin", "weave", "CNI plugin (weave, flannel, calico, canal)")
+	startCmd.Flags().String("flatcar-channel", "alpha", "Channel for Flatcar Linux (alpha, beta, stable)")
 }
 
 func runStart(cmd *cobra.Command, args []string) {
@@ -57,13 +58,14 @@ func doStart() {
 	numberNodes := viper.GetInt("nodes")
 	cniPluginDir := viper.GetString("cni-plugin-dir")
 	cniPlugin := viper.GetString("cni-plugin")
+	flatcarChannel := viper.GetString("flatcar-channel")
 
 	kluster, err := cluster.New(path.Join(kubespawnDir, "clusters", clusterName), clusterName)
 	if err != nil {
 		log.Fatalf("Failed to create cluster object: %v", err)
 	}
 
-	if err := kluster.Start(numberNodes, cniPluginDir, cniPlugin); err != nil {
+	if err := kluster.Start(numberNodes, cniPluginDir, cniPlugin, flatcarChannel); err != nil {
 		log.Fatalf("Failed to start cluster: %v", err)
 	}
 

--- a/pkg/bootstrap/node.go
+++ b/pkg/bootstrap/node.go
@@ -45,7 +45,6 @@ const (
 
 var (
 	BaseImageName string = "flatcar"
-	baseImageURL  string = "https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_developer_container.bin.bz2"
 
 	// minimum pool size should be around 2G, because Flatcar image is 1.6G.
 	minPoolSize int64 = 2 * 1024 * 1024 * 1024
@@ -698,7 +697,7 @@ func checkBaseImageVersion() error {
 	return nil
 }
 
-func pullBaseImage() error {
+func pullBaseImage(channelName string) error {
 	var cmdPath string
 	var err error
 
@@ -707,11 +706,13 @@ func pullBaseImage() error {
 		return fmt.Errorf("systemd-nspawn / machinectl not installed: %s", err)
 	}
 
+	ch := fmt.Sprintf("https://%s.release.flatcar-linux.net/amd64-usr/current/flatcar_developer_container.bin.bz2", channelName)
+
 	args := []string{
 		cmdPath,
 		"pull-raw",
 		"--verify=no",
-		baseImageURL,
+		ch,
 		BaseImageName,
 	}
 
@@ -738,14 +739,14 @@ func ensureBaseImageVersion() error {
 	return nil
 }
 
-func PrepareBaseImage() error {
+func PrepareBaseImage(channelName string) error {
 	// If no image exists, just download it
 	if !machinectl.ImageExists(BaseImageName) {
 		if err := EnlargeStoragePool(minPoolSize); err != nil {
 			return err
 		}
 		log.Printf("pulling %s image...", BaseImageName)
-		if err := pullBaseImage(); err != nil {
+		if err := pullBaseImage(channelName); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -355,11 +355,11 @@ func prepareBaseRootfs(rootfsDir string, clusterSettings *ClusterSettings) error
 	return nil
 }
 
-func (c *Cluster) Start(numberNodes int, cniPluginDir string, cniPlugin string) error {
+func (c *Cluster) Start(numberNodes int, cniPluginDir, cniPlugin, flatcarChannel string) error {
 	if numberNodes < 1 {
 		return errors.Errorf("cannot start less than 1 node")
 	}
-	if err := bootstrap.PrepareBaseImage(); err != nil {
+	if err := bootstrap.PrepareBaseImage(flatcarChannel); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Allow users to specify a certain channel name, like `alpha`, `beta`, or `stable`, when starting a cluster.

```
./kube-spawn start --flatcar-channel=beta
```

Note, we don't necessarily enforce one of the 3 channel names, because Flatcar could have other channel names in the future. When a wrong channel name is given, machinectl will anyway fail due to a wrong URL.

Fixes https://github.com/kinvolk/kube-spawn/issues/272