### PR TITLE
pkg/nspawntool: use transient scope to fix device cgroups issues

### DIFF
--- a/pkg/cnispawn/spawn.go
+++ b/pkg/cnispawn/spawn.go
@@ -53,6 +53,7 @@ func Spawn(cniPluginDir string, nspawnArgs []string) error {
 		"--bind-ro=/lib/modules",
 		"--boot",
 		"--notify-ready=yes",
+		"--keep-unit",
 	}
 
 	args = append(args, nspawnArgs...)


### PR DESCRIPTION
Starting from systemd v239, it's no more possible to create device nodes inside systemd-nspawn containers, because systemd-nspawn creates subcgroups for each machine slice under `/sys/fs/cgroup/devices`.

To make docker containers inside nspawn containers capable of creating devices, we need to do workaround. Let's pass `--keep-unit` to systemd-nspawn, and call `systemd-run --scope` for using the cni-spawn wrapper. Then the transient scope gets created with a proper `DevicePolicy` property for each invocation, printing out the CNI result to stdout like before. That way, we can avoid dealing with additional unit files to allow device creation.

Fixes https://github.com/kinvolk/kube-spawn/issues/324