### PR TITLE
Enable keyring and bind-mount /sys/kernel/security for privileged operation

### DIFF
--- a/pkg/cnispawn/spawn.go
+++ b/pkg/cnispawn/spawn.go
@@ -48,6 +48,9 @@ func Spawn(cniPluginDir string, nspawnArgs []string) error {
 	args := []string{
 		systemdNspawnPath,
 		"--capability=cap_audit_control,cap_audit_read,cap_audit_write,cap_audit_control,cap_block_suspend,cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_ipc_lock,cap_ipc_owner,cap_kill,cap_lease,cap_linux_immutable,cap_mac_admin,cap_mac_override,cap_mknod,cap_net_admin,cap_net_bind_service,cap_net_broadcast,cap_net_raw,cap_setgid,cap_setfcap,cap_setpcap,cap_setuid,cap_sys_admin,cap_sys_boot,cap_sys_chroot,cap_sys_module,cap_sys_nice,cap_sys_pacct,cap_sys_ptrace,cap_sys_rawio,cap_sys_resource,cap_sys_time,cap_sys_tty_config,cap_syslog,cap_wake_alarm",
+		"--system-call-filter=@keyring",
+		"--private-users=false",
+		"--bind=/sys/kernel/security",
 		"--bind=/sys/fs/cgroup",
 		"--bind-ro=/boot",
 		"--bind-ro=/lib/modules",


### PR DESCRIPTION
This resolves part of the issue referenced in
[#326](https://github.com/kinvolk/kube-spawn/issues/326) needed to run
privileged pods. However, I don't believe it is sufficient to fully
support a Pod which wants to run e.g. Docker-In-Docker.

Signed-off-by: Don Bowman <db@donbowman.ca>