### PR TITLE
Fix issues for running with k8s v1.13

### DIFF
--- a/cmd/kube-spawn/create.go
+++ b/cmd/kube-spawn/create.go
@@ -47,7 +47,7 @@ func init() {
 	kubespawnCmd.AddCommand(createCmd)
 
 	createCmd.Flags().String("container-runtime", "docker", "Runtime to use for the cluster (can be docker or rkt)")
-	createCmd.Flags().String("kubernetes-version", "v1.9.6", "Kubernetes version to install")
+	createCmd.Flags().String("kubernetes-version", "v1.12.3", "Kubernetes version to install")
 	createCmd.Flags().String("kubernetes-source-dir", "", "Path to directory with Kubernetes sources")
 	createCmd.Flags().String("hyperkube-image", "", "Kubernetes hyperkube image to use (if unset, upstream k8s is installed)")
 	createCmd.Flags().String("cni-plugin-dir", "/opt/cni/bin", "Path to directory with CNI plugins")

--- a/cmd/kube-spawn/up.go
+++ b/cmd/kube-spawn/up.go
@@ -39,7 +39,7 @@ func init() {
 	// Flags should be kept in sync with `start` and `create`
 
 	upCmd.Flags().String("container-runtime", "docker", "Runtime to use for the cluster (can be docker or rkt)")
-	upCmd.Flags().String("kubernetes-version", "v1.9.6", "Kubernetes version to install")
+	upCmd.Flags().String("kubernetes-version", "v1.12.3", "Kubernetes version to install")
 	upCmd.Flags().String("kubernetes-source-dir", "", "Path to directory with Kubernetes sources")
 	upCmd.Flags().String("hyperkube-image", "", "Kubernetes hyperkube image to use (if unset, upstream k8s is installed)")
 	upCmd.Flags().String("cni-plugin-dir", "/opt/cni/bin", "Path to directory with CNI plugins")

--- a/pkg/cluster/clusterfiles.go
+++ b/pkg/cluster/clusterfiles.go
@@ -105,7 +105,7 @@ Environment="KUBELET_EXTRA_ARGS=\
 --authentication-token-webhook"
 `
 
-const KubeadmConfigTmpl = `apiVersion: kubeadm.k8s.io/{{.KubeadmApiVersion}}
+const KubeadmConfigAlphaTmpl = `apiVersion: kubeadm.k8s.io/{{.KubeadmApiVersion}}
 kind: MasterConfiguration
 authorizationMode: AlwaysAllow
 apiServerExtraArgs:
@@ -124,6 +124,27 @@ networking:
 {{- end }}
 {{if .HyperkubeImage -}}
 unifiedControlPlaneImage: {{.HyperkubeImage}}
+{{- end }}
+`
+
+const KubeadmConfigBetaTmpl = `apiVersion: kubeadm.k8s.io/{{.KubeadmApiVersion}}
+kind: InitConfiguration
+---
+apiVersion: kubeadm.k8s.io/{{.KubeadmApiVersion}}
+kind: ClusterConfiguration
+controllerManager: {}
+{{if .PodNetworkCIDR -}}
+networking:
+  podSubnet: {{.PodNetworkCIDR}}
+{{- end }}
+{{if .HyperkubeImage -}}
+useHyperKubeImage: true
+{{- end }}
+{{if .ClusterCIDR -}}
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clusterCIDR: {{.ClusterCIDR}}
 {{- end }}
 `
 


### PR DESCRIPTION
Let's bump the default Kubernetes version to v1.12.3, the most secure up-to-date version. This is mostly because of the critical security issue https://github.com/kubernetes/kubernetes/issues/71411.

Apply CNI plugins outside of nspawn containers. Starting from k8s v1.13, the insecure port 8080 of kube-apiserver is not available any more, as it has been deprecated. So we cannot run `kubectl apply` inside of nspawn containers.

Kubeadm v1.13 or newer should run with a config with `apiVersion: v1beta1`. In case of apiVersion `v1alpha*`, the `InitConfiguration` part can contain `apiServerExtraArgs`, `authorizationMode`, and `controllerManagerExtraArgs`. However, in case of apiVersion  `v1beta*`, these option should be removed or moved into each corresponding part. Otherwise kubeadm would complain with json unmarshal errors.