### PR TITLE
pkg/cluster: do not require host-device CNI plugin

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -86,7 +86,7 @@ const (
 )
 
 var cniFiles = map[string][]string{
-	"base":    {"bridge", "dhcp", "host-device", "host-local", "ipvlan", "loopback", "macvlan", "portmap", "ptp", "sample", "tuning", "vlan"},
+	"base":    {"bridge", "dhcp", "host-local", "ipvlan", "loopback", "macvlan", "portmap", "ptp", "sample", "tuning", "vlan"},
 	"flannel": {"flannel"},
 	"calico":  {"calico", "calico-ipam"},
 	"canal":   {"flannel", "calico", "calico-ipam"},


### PR DESCRIPTION
The `host-device` plugin is not included in the CNI plugins v0.6.0, it's available starting from v0.7.0. Actually kube-spawn does not need the plugin to spawn the cluster.

Let's simply remove it from the required CNI plugins list.

Fixes https://github.com/kinvolk/kube-spawn/issues/334