### PR TITLE
pkg/cluster: upgrade weave to 2.5.1 to fix veth interface issue

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -73,7 +73,7 @@ func randString(n int) string {
 
 const (
 	validNameRegexpStr = "^[a-zA-Z0-9-]{1,50}$"
-	weaveNet           = "https://github.com/weaveworks/weave/releases/download/v2.0.5/weave-daemonset-k8s-1.7.yaml"
+	weaveNet           = "https://github.com/weaveworks/weave/releases/download/v2.5.1/weave-daemonset-k8s-1.8.yaml"
 	flannelNet         = "https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml"
 	calicoRBAC         = "https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml"
 


### PR DESCRIPTION
There has been a critical issue in kube-spawn with weave 2.0.5. Inside nspawn clusters, `veth*` interfaces are not created at all. As a result, coredns pods cannot start at all, and k8s nodes do not become ready at all. Apparently the yaml file provided by weave 2.0.5 is not compatible with the current k8s versions.

Let's upgrade it to 2.5.1, which seems to work fine.