### PR TITLE
pkg/cluster: don't copy 'sample' CNI plugin

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -86,7 +86,7 @@ const (
 )
 
 var cniFiles = map[string][]string{
-	"base":    {"bridge", "dhcp", "host-local", "ipvlan", "loopback", "macvlan", "portmap", "ptp", "sample", "tuning", "vlan"},
+	"base":    {"bridge", "dhcp", "host-local", "ipvlan", "loopback", "macvlan", "portmap", "ptp", "tuning", "vlan"},
 	"flannel": {"flannel"},
 	"calico":  {"calico", "calico-ipam"},
 	"canal":   {"flannel", "calico", "calico-ipam"},


### PR DESCRIPTION
CNI plugins 0.8.0 does not ship sample plugin anymore. It has been removed in
https://github.com/containernetworking/plugins/pull/295, so we shouldn't
attempt to copy it.

Closes #341