### PR TITLE
Dockerfile/Makefile: set GOCACHE to a shared volume on the host

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,6 @@
 FROM golang:latest
 
+ENV GOCACHE /tmp/.cache
 ENV GOPATH /go
 ENV PATH "/go/bin:${PATH}"
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DOCKER_TAG ?= latest
 PREFIX ?= /usr
 BINDIR ?= ${PREFIX}/bin
 UID=$(shell id -u)
+GOCACHEDIR=$(shell which go >/dev/null 2>&1 && go env GOCACHE || echo "$(HOME)/.cache/go-build")
 
 .PHONY: all clean dep install
 
@@ -12,8 +13,10 @@ VERSION=$(shell git describe --tags --always --dirty)
 ifeq ($(DOCKERIZED),y)
 all:
 	docker build -t kube-spawn-build:$(DOCKER_TAG) -f Dockerfile.build .
+	mkdir -p $(GOCACHEDIR)
 	docker run --rm -ti \
 		-v `pwd`:/go/src/github.com/kinvolk/kube-spawn:Z \
+		-v $(GOCACHEDIR):/tmp/.cache:Z \
 		--user $(UID):$(UID) \
 		kube-spawn-build
 else


### PR DESCRIPTION
Now that Go 1.12 or newer requires `GOCACHE`, a dockerized build fails with `permission denied` when initializing gocache.

To avoid such failures we should make a shared volume for the go cache to make it
available inside the container.